### PR TITLE
Bugfix: SkeletonText was breaking Flex grid in Overview page

### DIFF
--- a/lib/mirage/factories/team.ts
+++ b/lib/mirage/factories/team.ts
@@ -5,7 +5,7 @@ import { TEAM_GENDER } from 'src/components/Team/constants'
 
 export default Factory.extend({
   name: faker.commerce.department,
-  description: faker.lorem.paragraph,
+  description: faker.lorem.lines(5),
   currentProgress: () => faker.random.number({ min: 0, max: 100 }),
   currentConfidence: () => faker.random.number({ min: 0, max: 100 }),
   createdAt: faker.date.past,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.2.9",
         "@auth0/auth0-react": "^1.2.0",
-        "@chakra-ui/react": "^1.0.4",
+        "@chakra-ui/react": "^1.1.1",
         "@emotion/react": "^11.1.1",
         "@emotion/styled": "^11.0.0",
         "@koa/router": "^9.4.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.9",
     "@auth0/auth0-react": "^1.2.0",
-    "@chakra-ui/react": "^1.0.4",
+    "@chakra-ui/react": "^1.1.1",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
     "@koa/router": "^9.4.0",

--- a/src/components/Team/CardList/Card/card.tsx
+++ b/src/components/Team/CardList/Card/card.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Skeleton, SkeletonText, Text } from '@chakra-ui/react'
+import { Box, Flex, Heading, Skeleton, Text } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
 import { useRecoilValue } from 'recoil'
@@ -52,20 +52,20 @@ const TeamCard = ({ id }: TeamCardProperties) => {
             </Skeleton>
           </Flex>
 
-          <SkeletonText isLoaded={isLoaded} noOfLines={2} spacing="4">
+          {/* We are using Skeleton below as a workaround for this issue: */}
+          {/* https://github.com/chakra-ui/chakra-ui/issues/2956 */}
+          <Skeleton isLoaded={isLoaded} noOfLines={3} spacing="4">
             <Text color="gray.400" noOfLines={3}>
               {team?.description}
             </Text>
-          </SkeletonText>
-
-          <Skeleton isLoaded={isLoaded} borderRadius="full" height="12px">
+          </Skeleton>
+          <Skeleton isLoaded={isLoaded} borderRadius="full">
             <SliderWithFilledTrack
               value={team?.currentProgress}
               trackThickness="12px"
               trackColor={confidenceTag.color}
             />
           </Skeleton>
-
           <Box pt={12}>
             <DynamicAvatarGroup users={team?.users} isLoaded={isLoaded} />
           </Box>


### PR DESCRIPTION
## ☕ Purpose

This PR adds a workaround to solve the SkeletonText breaking our Overview page.

Related to: https://github.com/chakra-ui/chakra-ui/issues/2956