### PR TITLE
Hotfix: Null check-ins

### DIFF
--- a/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.spec.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.spec.tsx
@@ -89,4 +89,17 @@ describe('component expectations', () => {
 
     expect(comment.length).toEqual(1)
   })
+
+  it('passes a 0 difference when previous check-in is null', () => {
+    const confidence = faker.random.number()
+
+    const result = enzyme.shallow(
+      // eslint-disable-next-line unicorn/no-null
+      <KeyResultSectionTimelineCardCheckIn confidence={confidence} parent={null} />,
+    )
+
+    const confidenceTag = result.find('KeyResultSectionTimelineCardCheckInConfidenceTag')
+
+    expect(confidenceTag.prop('difference')).toEqual(0)
+  })
 })

--- a/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.tsx
@@ -19,7 +19,7 @@ export interface KeyResultSectionTimelineCardCheckInProperties {
   comment?: KeyResultCheckIn['comment']
   createdAt?: KeyResultCheckIn['createdAt']
   user?: User
-  parent?: KeyResultCheckIn
+  parent?: KeyResultCheckIn | null
 }
 
 const KeyResultSectionTimelineCardCheckIn = ({
@@ -32,8 +32,7 @@ const KeyResultSectionTimelineCardCheckIn = ({
 }: KeyResultSectionTimelineCardCheckInProperties) => {
   const intl = useIntl()
 
-  const confidenceDifference =
-    confidence && typeof parent !== 'undefined' ? confidence - parent.confidence : 100
+  const confidenceDifference = confidence && parent ? confidence - parent.confidence : 0
 
   return (
     <Box>

--- a/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/progress.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/progress.tsx
@@ -11,7 +11,7 @@ import messages from './messages'
 export interface KeyResultSectionTimelineCardCheckInProgressProperties {
   relativePercentageProgress?: KeyResultCheckIn['progress']
   confidence?: KeyResultCheckIn['confidence']
-  parent?: KeyResultCheckIn
+  parent?: KeyResultCheckIn | null
 }
 
 const normalizeProgress = (progress?: number) => (progress ? progress / 100 : 0)


### PR DESCRIPTION
## ☕ Purpose

This PR fixes some null check-ins that were bugging our platform.