### PR TITLE
Bugfix: Timeline check-in value increase mask

### DIFF
--- a/src/components/KeyResult/CheckInForm/queries.gql
+++ b/src/components/KeyResult/CheckInForm/queries.gql
@@ -2,6 +2,7 @@ mutation CREATE_KEY_RESULT_CHECK_IN($keyResultCheckInInput: KeyResultCheckInInpu
   createKeyResultCheckIn(keyResultCheckIn: $keyResultCheckInInput) {
     id
     value
+    valueIncrease
     confidence
     progress
     comment

--- a/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.spec.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.spec.tsx
@@ -12,6 +12,7 @@ describe('component expectations', () => {
 
   it('passes a positive difference when previous check-in has less confidence than the new one', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -27,7 +28,9 @@ describe('component expectations', () => {
       confidence,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const confidenceTag = result.find('KeyResultSectionTimelineCardCheckInRelativeConfidenceTag')
 
@@ -36,6 +39,7 @@ describe('component expectations', () => {
 
   it('can use a parent confidence of 0', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -51,7 +55,9 @@ describe('component expectations', () => {
       confidence,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const confidenceTag = result.find('KeyResultSectionTimelineCardCheckInRelativeConfidenceTag')
 
@@ -60,6 +66,7 @@ describe('component expectations', () => {
 
   it('passes a 0 difference when previous check-in has the same confidence as this one', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -74,7 +81,9 @@ describe('component expectations', () => {
       confidence,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const confidenceTag = result.find('KeyResultSectionTimelineCardCheckInRelativeConfidenceTag')
 
@@ -83,6 +92,7 @@ describe('component expectations', () => {
 
   it('passes a negative confidence when previous check-in has a bigger confidence than this one', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -98,7 +108,9 @@ describe('component expectations', () => {
       confidence,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const confidenceTag = result.find('KeyResultSectionTimelineCardCheckInRelativeConfidenceTag')
 
@@ -107,10 +119,13 @@ describe('component expectations', () => {
 
   it('does not display the comment section there is no comment', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} />,
+    )
 
     const comment = result.find('KeyResultSectionTimelineCardCheckInComment')
 
@@ -119,6 +134,7 @@ describe('component expectations', () => {
 
   it('displays the comment section if there is a comment', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -126,7 +142,9 @@ describe('component expectations', () => {
       comment: faker.lorem.paragraph(),
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const comment = result.find('KeyResultSectionTimelineCardCheckInComment')
 
@@ -135,6 +153,7 @@ describe('component expectations', () => {
 
   it('passes a 0 difference when previous check-in is null', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -144,7 +163,9 @@ describe('component expectations', () => {
       confidence,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const confidenceTag = result.find('KeyResultSectionTimelineCardCheckInRelativeConfidenceTag')
 
@@ -153,6 +174,7 @@ describe('component expectations', () => {
 
   it('does not show the value increase section if the value increase is zero', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useMutation').atLeast(1).returns([sinon.fake()])
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
@@ -160,7 +182,9 @@ describe('component expectations', () => {
       valueIncrease: 0,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const valueIncreaseSection = result.find('KeyResultSectionTimelineCardCheckInValueIncrease')
 
@@ -173,6 +197,7 @@ describe('component interactions', () => {
 
   it('triggers a delete action upon request', () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
     const spy = sinon.spy()
@@ -184,7 +209,9 @@ describe('component interactions', () => {
       id: fakeID,
     }
 
-    const result = enzyme.shallow(<KeyResultSectionTimelineCardCheckIn data={fakeData} />)
+    const result = enzyme.shallow(
+      <KeyResultSectionTimelineCardCheckIn keyResultID={faker.random.uuid()} data={fakeData} />,
+    )
 
     const base = result.find('KeyResultSectionTimelineCardBase')
     base.simulate('delete')
@@ -200,6 +227,7 @@ describe('component interactions', () => {
 
   it('triggers the onEntryDelete prop on delete action', async () => {
     sinon.mock(recoil).expects('useSetRecoilState').atLeast(1).returns(sinon.fake())
+    sinon.mock(recoil).expects('useRecoilValue').atLeast(1)
     sinon.mock(apollo).expects('useLazyQuery').atLeast(1).returns([sinon.fake()])
 
     const spy = sinon.spy()
@@ -212,7 +240,11 @@ describe('component interactions', () => {
     }
 
     const result = enzyme.shallow(
-      <KeyResultSectionTimelineCardCheckIn data={fakeData} onEntryDelete={spy} />,
+      <KeyResultSectionTimelineCardCheckIn
+        keyResultID={faker.random.uuid()}
+        data={fakeData}
+        onEntryDelete={spy}
+      />,
     )
 
     const base = result.find('KeyResultSectionTimelineCardBase')

--- a/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/check-in.tsx
@@ -2,10 +2,11 @@ import { useLazyQuery, useMutation } from '@apollo/client'
 import { Box, Stat, Flex, StatLabel } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
-import { useSetRecoilState } from 'recoil'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
 
 import KeyResultSectionTimelineCardBase from 'src/components/KeyResult/Single/Sections/Timeline/Cards/Base'
 import { KeyResult, KeyResultCheckIn } from 'src/components/KeyResult/types'
+import keyResultAtomFamily from 'src/state/recoil/key-result/atom-family'
 import selectLatestCheckIn from 'src/state/recoil/key-result/check-in/latest'
 import removeTimelineEntry from 'src/state/recoil/key-result/timeline/remove-entry'
 
@@ -19,7 +20,7 @@ import KeyResultSectionTimelineCardCheckInRelativeConfidenceTag from './relative
 import KeyResultSectionTimelineCardCheckInValueIncrease from './value-increase'
 
 export interface KeyResultSectionTimelineCardCheckInProperties {
-  format?: KeyResult['format']
+  keyResultID: KeyResult['id']
   data?: Partial<KeyResultCheckIn>
   onEntryDelete?: (entryType: string) => void
 }
@@ -29,11 +30,12 @@ export interface GetKeyResultWithLatestCheckInQuery {
 }
 
 const KeyResultSectionTimelineCardCheckIn = ({
-  format,
+  keyResultID,
   data,
   onEntryDelete,
 }: KeyResultSectionTimelineCardCheckInProperties) => {
   const intl = useIntl()
+  const keyResult = useRecoilValue(keyResultAtomFamily(keyResultID))
   const removeEntryFromTimeline = useSetRecoilState(removeTimelineEntry(data?.keyResultId))
   const setLatestCheckIn = useSetRecoilState(selectLatestCheckIn(data?.keyResultId))
   const [getKeyResultWithLatestCheckIn] = useLazyQuery<GetKeyResultWithLatestCheckInQuery>(
@@ -104,7 +106,7 @@ const KeyResultSectionTimelineCardCheckIn = ({
 
           {data?.valueIncrease !== 0 && (
             <KeyResultSectionTimelineCardCheckInValueIncrease
-              format={format}
+              format={keyResult?.format}
               value={data?.value}
               valueIncrease={data?.valueIncrease}
             />

--- a/src/components/KeyResult/Single/Sections/Timeline/Content/content.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Content/content.tsx
@@ -63,6 +63,7 @@ const KeyResultSectionTimelineContent = ({
         {timeline.map((entry) => (
           <KeyResultSectionTimelineContentEntry
             key={entry.id}
+            keyResultID={keyResultID}
             typename={entry.__typename}
             data={entry}
             onEntryDelete={onEntryDelete}

--- a/src/components/KeyResult/Single/Sections/Timeline/Content/entry.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Content/entry.tsx
@@ -4,16 +4,18 @@ import {
   KeyResultSectionTimelineCardCheckIn,
   KeyResultSectionTimelineCardComment,
 } from 'src/components/KeyResult/Single/Sections/Timeline/Cards'
-import { KeyResultCheckIn, KeyResultComment } from 'src/components/KeyResult/types'
+import { KeyResult, KeyResultCheckIn, KeyResultComment } from 'src/components/KeyResult/types'
 
 export interface KeyResultSectionTimelineContentEntryProperties<E> {
   typename: string
+  keyResultID: KeyResult['id']
   data: Partial<E>
   onEntryDelete?: (entryType: string) => void
 }
 
 const KeyResultSectionTimelineContentEntry = <E extends KeyResultCheckIn | KeyResultComment>({
   typename,
+  keyResultID,
   data,
   onEntryDelete,
 }: KeyResultSectionTimelineContentEntryProperties<E>) => {
@@ -24,7 +26,7 @@ const KeyResultSectionTimelineContentEntry = <E extends KeyResultCheckIn | KeyRe
   const TypenameComponent =
     typenameComponents[typename in typenameComponents ? typename : 'KeyResultComment']
 
-  return <TypenameComponent data={data} onEntryDelete={onEntryDelete} />
+  return <TypenameComponent keyResultID={keyResultID} data={data} onEntryDelete={onEntryDelete} />
 }
 
 export default KeyResultSectionTimelineContentEntry


### PR DESCRIPTION
## ☕ Purpose

This PR fixes the broken mask in the value increase section of our Key Result timeline.