### PR TITLE
Feature: Key-Result Checklist

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,6 @@
     "github.copilot",
     "eamodio.gitlens",
     "graphql.vscode-graphql",
-  	"esbenp.prettier-vscode"
+    "esbenp.prettier-vscode"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
 </p>
 <p align="center">
-Web interface for Bud's execution mode
+Web interface for Bud's execution mode.
 </p>
 
 ## 📖 About this

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -759,6 +759,10 @@
     "defaultMessage": "Um ícone de calendário. Ele indica que nesse campo fica o prazo do objetivo",
     "description": "The alternative text explaining our calendar icon in the objective accordion item"
   },
+  "SsQRcF": {
+    "defaultMessage": "Uma seta que ao ser clicada expande a checklist deste resultado-chave",
+    "description": "This message is used by screen readers to explain the collapse icon in our key-result sidebar on the checklist section"
+  },
   "SxsVDt": {
     "defaultMessage": "Meta",
     "description": "This is the label of the check-in form that indicates the goal for her/his key result"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1279,6 +1279,10 @@
     "defaultMessage": "Progresso",
     "description": "This message is displayed as the title of the progress section inside check-in card"
   },
+  "s4h8ne": {
+    "defaultMessage": "Adicionar uma Check-list",
+    "description": "This text is used as a button when the key-result has no check-marks"
+  },
   "s6b2FE": {
     "defaultMessage": "Data Limite",
     "description": "The heading text of the goal section in our key-result drawers"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -667,6 +667,10 @@
     "defaultMessage": "Minhas Key Result",
     "description": "The name of the Key Results page, located at \"/keyResults\""
   },
+  "PktsGq": {
+    "defaultMessage": "Check-list",
+    "description": "This is the title of our checklist section inside the key-result sidebar"
+  },
   "Q2diI+": {
     "defaultMessage": "Ícone de bóia. Ao clicar nele você irá para nossa página de suporte",
     "description": "SupportButton icon desc. This is used by screen readers for accessibility"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -635,6 +635,10 @@
     "defaultMessage": "Minha conta",
     "description": "MainAppBar user menu first item option"
   },
+  "O13rH5": {
+    "defaultMessage": "{completed}/{total}",
+    "description": "This messages is displayed in our our key-result drawer above the checklist as the count of total completed checkmarks"
+  },
   "OEfoTC": {
     "defaultMessage": "Um ícone de setas entrelaçadas. Ao clicar aqui você irá editar esse campo",
     "description": "This message is used by screen readers when the user is focusing on the component which contains the user name and picture. This component is used in multiple places, like: our header, the key-result drawers, and other"
@@ -819,6 +823,10 @@
     "defaultMessage": "Um desenho de fantasma, indicando que este resultado-chave não tem nenhum card de atividade",
     "description": "This text is used by screen readers to explain our ghost image inside our key result drawers"
   },
+  "W37c+K": {
+    "defaultMessage": "Um ícone de check. Ele representa a quantidade de itens marcados como completo em sua checklist",
+    "description": "This text is used by screen readers to explain the check icon in our key-result drawer checklist section"
+  },
   "W9swHV": {
     "defaultMessage": "Configurações",
     "description": "This tooltip is displayed when the user hovers the settings icon"
@@ -970,6 +978,10 @@
   "dymB9a": {
     "defaultMessage": "Cada resultado-chave pertence a um objetivo",
     "description": "This tooltip explains the second column of the key result list"
+  },
+  "e2FL3I": {
+    "defaultMessage": "Um ícone do sinal de positivo que, ao clicar, irá adicionar um novo item na checklist",
+    "description": "This is used by screen readers to understand the insert new check mark icon in our key-result drawer"
   },
   "e37pvj": {
     "defaultMessage": "Uma seta para baixo, indicando que ao clicar você irá abrir a lista de ciclos",
@@ -1239,6 +1251,10 @@
     "defaultMessage": "Um ícone circular, com bordas e um símbolo de mais ao centro",
     "description": "This is the desc text that is displayed for screen readers"
   },
+  "qYpqgw": {
+    "defaultMessage": "Novo item",
+    "description": "This is the description used as default by a check mark when we add a new item"
+  },
   "qytqsj": {
     "defaultMessage": "Trimestral",
     "description": "This text is used as prefix for our quarterly cadences"
@@ -1410,6 +1426,10 @@
   "ze3hqu": {
     "defaultMessage": "Estamos trabalhando em melhorias para você! :)",
     "description": "The title displayed in our under maintenance error page"
+  },
+  "zennqC": {
+    "defaultMessage": "Adicionar novo item",
+    "description": "This label appears in our key-result sidebar drawer, in the end of our checklist"
   },
   "zev4wl": {
     "defaultMessage": "Um ícone de bandeira, inidcando a meta do resultado-chave no qual você está fazendo check-in",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1303,6 +1303,10 @@
     "defaultMessage": "Mostrar menos",
     "description": "This text is displayed in the button that collapses the truncated text"
   },
+  "sSCvSb": {
+    "defaultMessage": "Um ícone de \"x\". Ao clicar nele você irá remover esse item da checklist",
+    "description": "This text is used by screen readers inside our key-result drawer to describe the X icon to remove a given item from the checklist"
+  },
   "sYGIlp": {
     "defaultMessage": "Minha conta",
     "description": "This label defines the text on the first menu section option"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1251,10 +1251,6 @@
     "defaultMessage": "Um ícone circular, com bordas e um símbolo de mais ao centro",
     "description": "This is the desc text that is displayed for screen readers"
   },
-  "qYpqgw": {
-    "defaultMessage": "Novo item",
-    "description": "This is the description used as default by a check mark when we add a new item"
-  },
   "qytqsj": {
     "defaultMessage": "Trimestral",
     "description": "This text is used as prefix for our quarterly cadences"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "execution-mode",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -13,7 +12,7 @@
         "@apollo/client": "^3.2.9",
         "@auth0/auth0-react": "^1.2.0",
         "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
-        "@chakra-ui/react": "^1.6.0",
+        "@chakra-ui/react": "^1.6.5",
         "@emotion/react": "^11.1.1",
         "@emotion/styled": "^11.0.0",
         "@koa/router": "^9.4.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@apollo/client": "^3.2.9",
     "@auth0/auth0-react": "^1.2.0",
     "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
-    "@chakra-ui/react": "^1.6.0",
+    "@chakra-ui/react": "^1.6.5",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
     "@koa/router": "^9.4.0",

--- a/src/components/Base/EditableControls/base-button.tsx
+++ b/src/components/Base/EditableControls/base-button.tsx
@@ -1,0 +1,15 @@
+import { IconButton, IconButtonProps } from '@chakra-ui/react'
+import React from 'react'
+
+export const EditableButton = (properties: IconButtonProps) => (
+  <IconButton
+    variant="solid"
+    h={12}
+    w={12}
+    fontSize="2xl"
+    bg="black.100"
+    color="gray.500"
+    borderColor="transparent"
+    {...properties}
+  />
+)

--- a/src/components/Base/EditableControls/cancel-button.tsx
+++ b/src/components/Base/EditableControls/cancel-button.tsx
@@ -1,0 +1,30 @@
+import { ButtonProps } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import TimesIcon from 'src/components/Icon/Times'
+
+import { EditableButton } from './base-button'
+import messages from './messages'
+
+interface CancelButtonProperties extends ButtonProps {
+  onCancel: () => void
+}
+
+export const CancelButton = ({ onCancel, ...rest }: CancelButtonProperties) => {
+  const intl = useIntl()
+
+  return (
+    <EditableButton
+      aria-label={intl.formatMessage(messages.cancelButtonDesc)}
+      _hover={{
+        color: 'white',
+        bg: 'red.500',
+      }}
+      onClick={onCancel}
+      {...rest}
+    >
+      <TimesIcon desc={intl.formatMessage(messages.cancelButtonDesc)} fill="currentColor" />
+    </EditableButton>
+  )
+}

--- a/src/components/Base/EditableControls/cancel-button.tsx
+++ b/src/components/Base/EditableControls/cancel-button.tsx
@@ -21,6 +21,10 @@ export const CancelButton = ({ onCancel, onClick, ...rest }: CancelButtonPropert
         color: 'white',
         bg: 'red.500',
       }}
+      _active={{
+        color: 'white',
+        bg: 'red.400',
+      }}
       onClick={onCancel ?? onClick}
       {...rest}
     >

--- a/src/components/Base/EditableControls/cancel-button.tsx
+++ b/src/components/Base/EditableControls/cancel-button.tsx
@@ -8,10 +8,10 @@ import { EditableButton } from './base-button'
 import messages from './messages'
 
 interface CancelButtonProperties extends ButtonProps {
-  onCancel: () => void
+  onCancel?: () => void
 }
 
-export const CancelButton = ({ onCancel, ...rest }: CancelButtonProperties) => {
+export const CancelButton = ({ onCancel, onClick, ...rest }: CancelButtonProperties) => {
   const intl = useIntl()
 
   return (
@@ -21,7 +21,7 @@ export const CancelButton = ({ onCancel, ...rest }: CancelButtonProperties) => {
         color: 'white',
         bg: 'red.500',
       }}
-      onClick={onCancel}
+      onClick={onCancel ?? onClick}
       {...rest}
     >
       <TimesIcon desc={intl.formatMessage(messages.cancelButtonDesc)} fill="currentColor" />

--- a/src/components/Base/EditableControls/confirm-button.tsx
+++ b/src/components/Base/EditableControls/confirm-button.tsx
@@ -1,0 +1,33 @@
+import { ButtonProps } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import CheckIcon from 'src/components/Icon/Check'
+
+import { EditableButton } from './base-button'
+import messages from './messages'
+
+interface ConfirmButtonProperties extends ButtonProps {
+  isLoading: boolean
+  isDisabled?: boolean
+}
+
+export const ConfirmButton = ({ isLoading, isDisabled, ...rest }: ConfirmButtonProperties) => {
+  const intl = useIntl()
+
+  return (
+    <EditableButton
+      isLoading={isLoading}
+      isDisabled={isDisabled}
+      aria-label={intl.formatMessage(messages.submitButtonDesc)}
+      type="submit"
+      _hover={{
+        color: isLoading || isDisabled ? 'gray.500' : 'white',
+        bg: isLoading || isDisabled ? 'gray.50' : 'green.500',
+      }}
+      {...rest}
+    >
+      <CheckIcon desc={intl.formatMessage(messages.submitButtonDesc)} fill="currentColor" />
+    </EditableButton>
+  )
+}

--- a/src/components/Base/EditableControls/confirm-button.tsx
+++ b/src/components/Base/EditableControls/confirm-button.tsx
@@ -21,9 +21,13 @@ export const ConfirmButton = ({ isLoading, isDisabled, ...rest }: ConfirmButtonP
       isDisabled={isDisabled}
       aria-label={intl.formatMessage(messages.submitButtonDesc)}
       type="submit"
+      color="white"
+      bg="brand.500"
       _hover={{
-        color: isLoading || isDisabled ? 'gray.500' : 'white',
-        bg: isLoading || isDisabled ? 'gray.50' : 'green.500',
+        bg: isLoading || isDisabled ? 'brand.500' : 'brand.400',
+      }}
+      _active={{
+        bg: isLoading || isDisabled ? 'brand.500' : 'brand.300',
       }}
       {...rest}
     >

--- a/src/components/Base/EditableControls/confirm-button.tsx
+++ b/src/components/Base/EditableControls/confirm-button.tsx
@@ -8,7 +8,7 @@ import { EditableButton } from './base-button'
 import messages from './messages'
 
 interface ConfirmButtonProperties extends ButtonProps {
-  isLoading: boolean
+  isLoading?: boolean
   isDisabled?: boolean
 }
 

--- a/src/components/Base/EditableControls/edit-button.tsx
+++ b/src/components/Base/EditableControls/edit-button.tsx
@@ -1,0 +1,37 @@
+import { ButtonProps, IconButton } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import PenIcon from 'src/components/Icon/Pen'
+
+import messages from './messages'
+
+interface EditButtonProperties extends ButtonProps {
+  isHovering?: boolean
+  isLocked?: boolean
+}
+
+export const EditButton = ({ isHovering, isLocked, ...rest }: EditButtonProperties) => {
+  const intl = useIntl()
+
+  return (
+    <IconButton
+      aria-label={intl.formatMessage(messages.editableIconDesc)}
+      icon={
+        <PenIcon
+          fill="brand.400"
+          opacity={isHovering && !isLocked ? 1 : 0}
+          display={isLocked ? 'none' : 'inherit'}
+          transition="opacity .2s ease-out"
+          desc={intl.formatMessage(messages.editableIconDesc)}
+          title={intl.formatMessage(messages.editableIconTitle)}
+        />
+      }
+      {...rest}
+      p={0}
+      minW="auto"
+      w="auto"
+      h="auto"
+    />
+  )
+}

--- a/src/components/Base/EditableControls/messages.ts
+++ b/src/components/Base/EditableControls/messages.ts
@@ -1,0 +1,21 @@
+import { defineMessages } from 'react-intl'
+
+type EditableControlsMessage = 'cancelButtonDesc' | 'submitButtonDesc'
+
+export default defineMessages<EditableControlsMessage>({
+  cancelButtonDesc: {
+    defaultMessage:
+      'Um botão com um ícone de X. Ao clicar nele você irá cancelar a atualização do objetivo',
+    id: 'npWxt7',
+    description:
+      'This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the cancel button',
+  },
+
+  submitButtonDesc: {
+    defaultMessage:
+      'Um botão com um ícone de confirmação. Ao clicar nele você irá salvar sua atualização do objetivo',
+    id: 'xfx/rc',
+    description:
+      'This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the check button',
+  },
+})

--- a/src/components/Base/EditableControls/messages.ts
+++ b/src/components/Base/EditableControls/messages.ts
@@ -1,6 +1,10 @@
 import { defineMessages } from 'react-intl'
 
-type EditableControlsMessage = 'cancelButtonDesc' | 'submitButtonDesc'
+type EditableControlsMessage =
+  | 'cancelButtonDesc'
+  | 'submitButtonDesc'
+  | 'editableIconDesc'
+  | 'editableIconTitle'
 
 export default defineMessages<EditableControlsMessage>({
   cancelButtonDesc: {
@@ -17,5 +21,18 @@ export default defineMessages<EditableControlsMessage>({
     id: 'xfx/rc',
     description:
       'This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the check button',
+  },
+
+  editableIconDesc: {
+    defaultMessage: 'Um ícone de caneta. Ao clicar nele você irá editar esse campo',
+    id: 'pLYuso',
+    description:
+      'The description for our pen icon. This message is used by screen readers to improve our accesibility',
+  },
+
+  editableIconTitle: {
+    defaultMessage: 'Clique aqui para editar esse campo',
+    id: 'WKevJy',
+    description: 'The title for our pen icon. This message is displayed in our UI as a tooltip',
   },
 })

--- a/src/components/Base/EditableControls/wrapper.tsx
+++ b/src/components/Base/EditableControls/wrapper.tsx
@@ -1,5 +1,35 @@
+import { ButtonProps, HStack, useEditableControls } from '@chakra-ui/react'
 import React from 'react'
 
-export const EditableControls = () => {
-  return <p>Ok</p>
+import { CancelButton } from './cancel-button'
+import { ConfirmButton } from './confirm-button'
+import { EditButton } from './edit-button'
+
+type EditableControlsProperties = {
+  isHovering?: boolean
+  isLocked?: boolean
+}
+
+export const EditableControls = ({ isHovering, isLocked }: EditableControlsProperties) => {
+  const { isEditing, getEditButtonProps, getSubmitButtonProps, getCancelButtonProps } =
+    useEditableControls()
+  const commonProperties: ButtonProps = {
+    fontSize: 'md',
+    h: 10,
+    w: 10,
+  }
+
+  return isEditing ? (
+    <HStack>
+      <CancelButton {...getCancelButtonProps()} {...commonProperties} />
+      <ConfirmButton {...getSubmitButtonProps()} {...commonProperties} />
+    </HStack>
+  ) : (
+    <EditButton
+      isHovering={isHovering}
+      isLocked={isLocked}
+      {...getEditButtonProps()}
+      {...commonProperties}
+    />
+  )
 }

--- a/src/components/Base/EditableControls/wrapper.tsx
+++ b/src/components/Base/EditableControls/wrapper.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const EditableControls = () => {
+  return <p>Ok</p>
+}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -1,5 +1,5 @@
 import { Stack, FormLabel, StackProps, EditableProps, Spinner } from '@chakra-ui/react'
-import React, { useEffect, useState } from 'react'
+import React, { KeyboardEvent, useEffect, useState } from 'react'
 
 import EditableInputValue from 'src/components/Base/EditableInputValue'
 
@@ -15,6 +15,7 @@ export interface EditableInputFieldProperties {
   startWithEditView?: boolean
   autoFocus?: boolean
   isDisabled?: boolean
+  onPressedEnter?: () => void
 }
 
 const EditableInputField = ({
@@ -29,12 +30,17 @@ const EditableInputField = ({
   startWithEditView,
   autoFocus,
   isDisabled,
+  onPressedEnter,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
   const handleSubmit = (value: string) => {
     setWasSubmitted(true)
     if (onSubmit) onSubmit(value)
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!isDisabled && event.key === 'Enter' && onPressedEnter) onPressedEnter()
   }
 
   const isBeingSubmitted = isSubmitting && wasSubmitted
@@ -61,6 +67,7 @@ const EditableInputField = ({
           autoFocus={autoFocus}
           isDisabled={isDisabled}
           onSubmit={handleSubmit}
+          onKeyDown={handleKeyDown}
         />
         {(isBeingSubmitted || isWaiting) && <Spinner color="gray.200" size="sm" />}
       </Stack>

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -18,7 +18,7 @@ export interface EditableInputFieldProperties {
   onPressedEnter?: () => void
   onStartEdit?: () => void
   onStopEdit?: () => void
-  showControls?: boolean
+  hideControls?: boolean
 }
 
 const EditableInputField = ({
@@ -36,7 +36,7 @@ const EditableInputField = ({
   onPressedEnter,
   onStartEdit,
   onStopEdit,
-  showControls,
+  hideControls,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -72,7 +72,7 @@ const EditableInputField = ({
           startWithEditView={startWithEditView}
           autoFocus={autoFocus}
           isDisabled={isDisabled}
-          showControls={showControls}
+          hideControls={hideControls}
           onSubmit={handleSubmit}
           onKeyDown={handleKeyDown}
           onStartEdit={onStartEdit}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -18,6 +18,7 @@ export interface EditableInputFieldProperties {
   onPressedEnter?: () => void
   onStartEdit?: () => void
   onStopEdit?: () => void
+  showControls?: boolean
 }
 
 const EditableInputField = ({
@@ -35,6 +36,7 @@ const EditableInputField = ({
   onPressedEnter,
   onStartEdit,
   onStopEdit,
+  showControls,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -70,6 +72,7 @@ const EditableInputField = ({
           startWithEditView={startWithEditView}
           autoFocus={autoFocus}
           isDisabled={isDisabled}
+          showControls={showControls}
           onSubmit={handleSubmit}
           onKeyDown={handleKeyDown}
           onStartEdit={onStartEdit}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -15,7 +15,7 @@ export interface EditableInputFieldProperties {
   startWithEditView?: boolean
   autoFocus?: boolean
   isDisabled?: boolean
-  onPressedEnter?: () => void
+  onPressedEnter?: (value?: string) => void
   onStartEdit?: () => void
   onStopEdit?: () => void
   onCancel?: (oldValue?: string) => void
@@ -48,7 +48,8 @@ const EditableInputField = ({
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (!isDisabled && event.key === 'Enter' && onPressedEnter) onPressedEnter()
+    if (!isDisabled && event.key === 'Enter' && onPressedEnter)
+      onPressedEnter(event.currentTarget.value)
   }
 
   const isBeingSubmitted = isSubmitting && wasSubmitted

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -60,7 +60,7 @@ const EditableInputField = ({
 
   return (
     <Stack direciton="column" w="full" spacing={0} flexGrow={flexGrow}>
-      {Boolean(label) ?? (
+      {Boolean(label) && (
         <FormLabel fontSize="sm" m={0}>
           {label}
         </FormLabel>

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -16,6 +16,8 @@ export interface EditableInputFieldProperties {
   autoFocus?: boolean
   isDisabled?: boolean
   onPressedEnter?: () => void
+  onStartEdit?: () => void
+  onStopEdit?: () => void
 }
 
 const EditableInputField = ({
@@ -31,6 +33,8 @@ const EditableInputField = ({
   autoFocus,
   isDisabled,
   onPressedEnter,
+  onStartEdit,
+  onStopEdit,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -68,6 +72,8 @@ const EditableInputField = ({
           isDisabled={isDisabled}
           onSubmit={handleSubmit}
           onKeyDown={handleKeyDown}
+          onStartEdit={onStartEdit}
+          onStopEdit={onStopEdit}
         />
         {(isBeingSubmitted || isWaiting) && <Spinner color="gray.200" size="sm" />}
       </Stack>

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -13,6 +13,7 @@ export interface EditableInputFieldProperties {
   isSubmitting?: boolean
   isWaiting?: boolean
   startWithEditView?: boolean
+  autoFocus?: boolean
 }
 
 const EditableInputField = ({
@@ -25,6 +26,7 @@ const EditableInputField = ({
   isSubmitting,
   isWaiting,
   startWithEditView,
+  autoFocus,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -54,6 +56,7 @@ const EditableInputField = ({
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           isSubmitting={isBeingSubmitted || isWaiting}
           startWithEditView={startWithEditView}
+          autoFocus={autoFocus}
           onSubmit={handleSubmit}
         />
         {(isBeingSubmitted || isWaiting) && <Spinner color="gray.200" size="sm" />}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -12,6 +12,7 @@ export interface EditableInputFieldProperties {
   isLoaded?: boolean
   isSubmitting?: boolean
   isWaiting?: boolean
+  startWithEditView?: boolean
 }
 
 const EditableInputField = ({
@@ -23,6 +24,7 @@ const EditableInputField = ({
   isLoaded,
   isSubmitting,
   isWaiting,
+  startWithEditView,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -51,6 +53,7 @@ const EditableInputField = ({
           isLoaded={isLoaded}
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           isSubmitting={isBeingSubmitted || isWaiting}
+          startWithEditView={startWithEditView}
           onSubmit={handleSubmit}
         />
         {(isBeingSubmitted || isWaiting) && <Spinner color="gray.200" size="sm" />}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -4,13 +4,14 @@ import React, { useEffect, useState } from 'react'
 import EditableInputValue from 'src/components/Base/EditableInputValue'
 
 export interface EditableInputFieldProperties {
-  label: string
+  label?: string
   customFallbackValue?: string
   value?: string
   flexGrow?: StackProps['flexGrow']
   onSubmit?: EditableProps['onSubmit']
   isLoaded?: boolean
   isSubmitting?: boolean
+  isWaiting?: boolean
 }
 
 const EditableInputField = ({
@@ -21,6 +22,7 @@ const EditableInputField = ({
   onSubmit,
   isLoaded,
   isSubmitting,
+  isWaiting,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -28,6 +30,8 @@ const EditableInputField = ({
     setWasSubmitted(true)
     if (onSubmit) onSubmit(value)
   }
+
+  const isBeingSubmitted = isSubmitting && wasSubmitted
 
   useEffect(() => {
     if (wasSubmitted && !isSubmitting) setWasSubmitted(false)
@@ -43,10 +47,11 @@ const EditableInputField = ({
           value={value}
           customFallbackValue={customFallbackValue}
           isLoaded={isLoaded}
-          isSubmitting={isSubmitting && wasSubmitted}
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          isSubmitting={isBeingSubmitted || isWaiting}
           onSubmit={handleSubmit}
         />
-        {isSubmitting && wasSubmitted && <Spinner color="gray.200" size="sm" />}
+        {(isBeingSubmitted || isWaiting) && <Spinner color="gray.200" size="sm" />}
       </Stack>
     </Stack>
   )

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -39,9 +39,11 @@ const EditableInputField = ({
 
   return (
     <Stack direciton="column" w="full" spacing={0} flexGrow={flexGrow}>
-      <FormLabel fontSize="sm" m={0}>
-        {label}
-      </FormLabel>
+      {Boolean(label) ?? (
+        <FormLabel fontSize="sm" m={0}>
+          {label}
+        </FormLabel>
+      )}
       <Stack direction="row" alignItems="center" gridGap={2}>
         <EditableInputValue
           value={value}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -18,6 +18,7 @@ export interface EditableInputFieldProperties {
   onPressedEnter?: () => void
   onStartEdit?: () => void
   onStopEdit?: () => void
+  onCancel?: (oldValue?: string) => void
   hideControls?: boolean
 }
 
@@ -36,6 +37,7 @@ const EditableInputField = ({
   onPressedEnter,
   onStartEdit,
   onStopEdit,
+  onCancel,
   hideControls,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
@@ -73,6 +75,7 @@ const EditableInputField = ({
           autoFocus={autoFocus}
           isDisabled={isDisabled}
           hideControls={hideControls}
+          onCancel={onCancel}
           onSubmit={handleSubmit}
           onKeyDown={handleKeyDown}
           onStartEdit={onStartEdit}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -1,4 +1,11 @@
-import { Stack, FormLabel, StackProps, EditableProps, Spinner } from '@chakra-ui/react'
+import {
+  Stack,
+  FormLabel,
+  StackProps,
+  EditableProps,
+  Spinner,
+  EditablePreviewProps,
+} from '@chakra-ui/react'
 import React, { KeyboardEvent, useEffect, useState } from 'react'
 
 import EditableInputValue from 'src/components/Base/EditableInputValue'
@@ -20,6 +27,7 @@ export interface EditableInputFieldProperties {
   onStopEdit?: () => void
   onCancel?: (oldValue?: string) => void
   hideControls?: boolean
+  previewProperties?: EditablePreviewProps
 }
 
 const EditableInputField = ({
@@ -39,6 +47,7 @@ const EditableInputField = ({
   onStopEdit,
   onCancel,
   hideControls,
+  previewProperties,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -76,6 +85,7 @@ const EditableInputField = ({
           autoFocus={autoFocus}
           isDisabled={isDisabled}
           hideControls={hideControls}
+          previewProperties={previewProperties}
           onCancel={onCancel}
           onSubmit={handleSubmit}
           onKeyDown={handleKeyDown}

--- a/src/components/Base/EditableInputField/editable-input-field.tsx
+++ b/src/components/Base/EditableInputField/editable-input-field.tsx
@@ -14,6 +14,7 @@ export interface EditableInputFieldProperties {
   isWaiting?: boolean
   startWithEditView?: boolean
   autoFocus?: boolean
+  isDisabled?: boolean
 }
 
 const EditableInputField = ({
@@ -27,6 +28,7 @@ const EditableInputField = ({
   isWaiting,
   startWithEditView,
   autoFocus,
+  isDisabled,
 }: EditableInputFieldProperties) => {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
@@ -57,6 +59,7 @@ const EditableInputField = ({
           isSubmitting={isBeingSubmitted || isWaiting}
           startWithEditView={startWithEditView}
           autoFocus={autoFocus}
+          isDisabled={isDisabled}
           onSubmit={handleSubmit}
         />
         {(isBeingSubmitted || isWaiting) && <Spinner color="gray.200" size="sm" />}

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -175,6 +175,8 @@ const EditableInputValue = ({
                   color={isHovering && !isLocked ? 'brand.500' : defaultColor}
                   fontWeight={400}
                   cursor={isLocked ? 'auto' : 'pointer'}
+                  wordBreak="break-all"
+                  py={0}
                   {...previewProperties}
                 />
                 <EditableInput

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -9,12 +9,15 @@ import {
   EditablePreviewProps,
   Button,
   useTheme,
+  HStack,
 } from '@chakra-ui/react'
 import React, { useEffect, useState, KeyboardEvent } from 'react'
 import { useIntl } from 'react-intl'
 
 import buildSkeletonMinSize from 'lib/chakra/build-skeleton-min-size'
 import PenIcon from 'src/components/Icon/Pen'
+
+import { EditableControls } from '../EditableControls/wrapper'
 
 import messages from './messages'
 
@@ -35,6 +38,7 @@ export interface EditableInputValueProperties {
   onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
   onStartEdit?: () => void
   onStopEdit?: () => void
+  showControls?: boolean
 }
 
 const truncateValue = (value?: string | null, maxCharacters?: number): string =>
@@ -57,6 +61,7 @@ const EditableInputValue = ({
   onKeyDown,
   onStartEdit,
   onStopEdit,
+  showControls,
 }: EditableInputValueProperties) => {
   const intl = useIntl()
 
@@ -157,7 +162,7 @@ const EditableInputValue = ({
           onCancel={handleCancel}
         >
           {({ isEditing, onEdit }) => (
-            <>
+            <HStack>
               <Box>
                 <Stack
                   direction="row"
@@ -198,7 +203,9 @@ const EditableInputValue = ({
                 onKeyDown={onKeyDown}
                 {...isDisableFix}
               />
-            </>
+
+              {showControls && isEditing && <EditableControls />}
+            </HStack>
           )}
         </Editable>
       ) : (

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -175,7 +175,7 @@ const EditableInputValue = ({
                   color={isHovering && !isLocked ? 'brand.500' : defaultColor}
                   fontWeight={400}
                   cursor={isLocked ? 'auto' : 'pointer'}
-                  wordBreak="break-all"
+                  wordBreak="break-word"
                   py={0}
                   {...previewProperties}
                 />

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -31,6 +31,7 @@ export interface EditableInputValueProperties {
   isTruncated?: boolean
   isDisabled?: boolean
   startWithEditView?: boolean
+  autoFocus?: boolean
 }
 
 const truncateValue = (value?: string | null, maxCharacters?: number): string =>
@@ -49,6 +50,7 @@ const EditableInputValue = ({
   isTruncated,
   isDisabled,
   startWithEditView,
+  autoFocus,
 }: EditableInputValueProperties) => {
   const intl = useIntl()
 
@@ -176,6 +178,7 @@ const EditableInputValue = ({
               </Box>
 
               <EditableInput
+                autoFocus={autoFocus}
                 borderWidth={isDisabled ? 0 : components.Editable.baseStyle.input.borderWidth}
                 {...isDisableFix}
               />

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -33,6 +33,8 @@ export interface EditableInputValueProperties {
   startWithEditView?: boolean
   autoFocus?: boolean
   onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
+  onStartEdit?: () => void
+  onStopEdit?: () => void
 }
 
 const truncateValue = (value?: string | null, maxCharacters?: number): string =>
@@ -53,6 +55,8 @@ const EditableInputValue = ({
   startWithEditView,
   autoFocus,
   onKeyDown,
+  onStartEdit,
+  onStopEdit,
 }: EditableInputValueProperties) => {
   const intl = useIntl()
 
@@ -83,6 +87,7 @@ const EditableInputValue = ({
 
   const handleEdit = () => {
     setIsExpanded(true)
+    if (onStartEdit) onStartEdit()
   }
 
   const handleChange = (value: string) => {
@@ -95,6 +100,11 @@ const EditableInputValue = ({
     setIsExpanded(!isTruncated)
 
     if (onSubmit) onSubmit(value)
+    if (onStopEdit) onStopEdit()
+  }
+
+  const handleCancel = () => {
+    if (onStopEdit) onStopEdit()
   }
 
   const toggleExpanded = () => {
@@ -144,6 +154,7 @@ const EditableInputValue = ({
           onSubmit={handleSubmit}
           onEdit={handleEdit}
           onChange={handleChange}
+          onCancel={handleCancel}
         >
           {({ isEditing, onEdit }) => (
             <>

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -122,7 +122,9 @@ const EditableInputValue = ({
         color: previewProperties?.color ?? defaultColor,
         fontSize: previewProperties?.fontSize ?? 'md',
         fontWeight: previewProperties?.fontWeight ?? 400,
-        p: previewProperties?.p,
+        px: '0.125rem',
+        py: '0.4rem',
+        cursor: 'text',
       }
     : {}
 

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -30,6 +30,7 @@ export interface EditableInputValueProperties {
   maxCharacters?: number
   isTruncated?: boolean
   isDisabled?: boolean
+  startWithEditView?: boolean
 }
 
 const truncateValue = (value?: string | null, maxCharacters?: number): string =>
@@ -47,6 +48,7 @@ const EditableInputValue = ({
   maxCharacters,
   isTruncated,
   isDisabled,
+  startWithEditView,
 }: EditableInputValueProperties) => {
   const intl = useIntl()
 
@@ -125,12 +127,14 @@ const EditableInputValue = ({
   return (
     <Skeleton
       isLoaded={isLoaded}
+      fadeDuration={0}
       {...buildSkeletonMinSize(isLoaded, skeletonWidth, skeletonHeight)}
     >
       {isLoaded ? (
         <Editable
           value={currentValue}
           isDisabled={isLocked}
+          startWithEditView={startWithEditView}
           onSubmit={handleSubmit}
           onEdit={handleEdit}
           onChange={handleChange}

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -10,7 +10,7 @@ import {
   Button,
   useTheme,
 } from '@chakra-ui/react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, KeyboardEvent } from 'react'
 import { useIntl } from 'react-intl'
 
 import buildSkeletonMinSize from 'lib/chakra/build-skeleton-min-size'
@@ -32,6 +32,7 @@ export interface EditableInputValueProperties {
   isDisabled?: boolean
   startWithEditView?: boolean
   autoFocus?: boolean
+  onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
 }
 
 const truncateValue = (value?: string | null, maxCharacters?: number): string =>
@@ -51,6 +52,7 @@ const EditableInputValue = ({
   isDisabled,
   startWithEditView,
   autoFocus,
+  onKeyDown,
 }: EditableInputValueProperties) => {
   const intl = useIntl()
 
@@ -182,6 +184,7 @@ const EditableInputValue = ({
               <EditableInput
                 autoFocus={autoFocus}
                 borderWidth={isDisabled ? 0 : components.Editable.baseStyle.input.borderWidth}
+                onKeyDown={onKeyDown}
                 {...isDisableFix}
               />
             </>

--- a/src/components/Base/EditableInputValue/editable-input-value.tsx
+++ b/src/components/Base/EditableInputValue/editable-input-value.tsx
@@ -37,6 +37,7 @@ export interface EditableInputValueProperties {
   onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
   onStartEdit?: () => void
   onStopEdit?: () => void
+  onCancel?: (oldValue?: string) => void
   hideControls?: boolean
 }
 
@@ -61,6 +62,7 @@ const EditableInputValue = ({
   onStartEdit,
   onStopEdit,
   hideControls,
+  onCancel,
 }: EditableInputValueProperties) => {
   const intl = useIntl()
 
@@ -99,21 +101,16 @@ const EditableInputValue = ({
   }
 
   const handleSubmit = (value: string) => {
-    const isSameAsExpanded = value === expandedValue
-    const isSameAsTruncated = value === truncatedValue
-    const isSame = isSameAsExpanded || isSameAsTruncated
+    setExpandedValue(value)
+    setTruncatedValue(truncateValue(value, maxCharacters))
+    setIsExpanded(!isTruncated)
 
-    if (!isSame) {
-      setExpandedValue(value)
-      setTruncatedValue(truncateValue(value, maxCharacters))
-      setIsExpanded(!isTruncated)
-
-      if (onSubmit) onSubmit(value)
-      if (onStopEdit) onStopEdit()
-    }
+    if (onSubmit) onSubmit(value)
+    if (onStopEdit) onStopEdit()
   }
 
-  const handleCancel = () => {
+  const handleCancel = (oldValue?: string) => {
+    if (onCancel) onCancel(oldValue)
     if (onStopEdit) onStopEdit()
   }
 

--- a/src/components/Base/EditableInputValue/messages.ts
+++ b/src/components/Base/EditableInputValue/messages.ts
@@ -1,11 +1,6 @@
 import { defineMessages } from 'react-intl'
 
-type EditableInputValueMessage =
-  | 'fallbackValue'
-  | 'editableIconDesc'
-  | 'editableIconTitle'
-  | 'collapseButton'
-  | 'expandButton'
+type EditableInputValueMessage = 'fallbackValue' | 'collapseButton' | 'expandButton'
 
 export default defineMessages<EditableInputValueMessage>({
   fallbackValue: {
@@ -13,19 +8,6 @@ export default defineMessages<EditableInputValueMessage>({
     id: 'eI6jYw',
     description:
       'The fallback value appears if no value is defined for that input. This input is customizable, so it will only appears if no value is defined, and no custom fallback value was provided',
-  },
-
-  editableIconDesc: {
-    defaultMessage: 'Um ícone de caneta. Ao clicar nele você irá editar esse campo',
-    id: 'pLYuso',
-    description:
-      'The description for our pen icon. This message is used by screen readers to improve our accesibility',
-  },
-
-  editableIconTitle: {
-    defaultMessage: 'Clique aqui para editar esse campo',
-    id: 'WKevJy',
-    description: 'The title for our pen icon. This message is displayed in our UI as a tooltip',
   },
 
   expandButton: {

--- a/src/components/KeyResult/List/Body/Columns/Actions/delete.tsx
+++ b/src/components/KeyResult/List/Body/Columns/Actions/delete.tsx
@@ -73,9 +73,16 @@ export const DeleteAction = ({ id, onDelete }: DeleteActionProperties) => {
         variant="solid"
         bg="black.100"
         color="gray.500"
+        borderColor="black.100"
         _hover={{
           bg: 'red.500',
           color: 'white',
+          borderColor: 'red.500',
+        }}
+        _active={{
+          bg: 'red.400',
+          color: 'white',
+          borderColor: 'red.400',
         }}
         onClick={handleOpen}
       >

--- a/src/components/KeyResult/Single/Drawer/Body/body.tsx
+++ b/src/components/KeyResult/Single/Drawer/Body/body.tsx
@@ -66,7 +66,7 @@ const KeyResultDrawerBody = ({ keyResultID, isLoading }: KeyResultDrawerBodyProp
 
         <KeyResultSectionDescription keyResultID={keyResultID} isLoading={isLoading} />
 
-        <KeyResultChecklistWrapper keyResultID={keyResultID} isLoading={isLoading} />
+        <KeyResultChecklistWrapper keyResultID={keyResultID} />
         <Divider borderColor="gray.100" />
 
         <KeyResultSectionOwner keyResultID={keyResultID} />

--- a/src/components/KeyResult/Single/Drawer/Body/body.tsx
+++ b/src/components/KeyResult/Single/Drawer/Body/body.tsx
@@ -11,6 +11,8 @@ import { KeyResultSingleSectionDeadline } from 'src/components/KeyResult/Single/
 import { KeyResultSingleSectionGoal } from 'src/components/KeyResult/Single/Sections/Goal/wrapper'
 import { KeyResult } from 'src/components/KeyResult/types'
 
+import { KeyResultChecklistWrapper } from '../../Sections/Checklist/wrapper'
+
 import { SCROLLBAR_ID } from './constants'
 
 export interface KeyResultDrawerBodyProperties {
@@ -63,6 +65,9 @@ const KeyResultDrawerBody = ({ keyResultID, isLoading }: KeyResultDrawerBodyProp
         <Divider borderColor="gray.100" />
 
         <KeyResultSectionDescription keyResultID={keyResultID} isLoading={isLoading} />
+
+        <KeyResultChecklistWrapper keyResultID={keyResultID} isLoading={isLoading} />
+        <Divider borderColor="gray.100" />
 
         <KeyResultSectionOwner keyResultID={keyResultID} />
       </Stack>

--- a/src/components/KeyResult/Single/Drawer/Body/body.tsx
+++ b/src/components/KeyResult/Single/Drawer/Body/body.tsx
@@ -1,5 +1,6 @@
 import { Box, Divider, Portal, Stack } from '@chakra-ui/react'
 import React, { useRef } from 'react'
+import { useRecoilValue } from 'recoil'
 
 import {
   KeyResultSectionDescription,
@@ -9,7 +10,10 @@ import {
 } from 'src/components/KeyResult/Single/Sections'
 import { KeyResultSingleSectionDeadline } from 'src/components/KeyResult/Single/Sections/Deadline/wrapper'
 import { KeyResultSingleSectionGoal } from 'src/components/KeyResult/Single/Sections/Goal/wrapper'
+import { KEY_RESULT_FORMAT } from 'src/components/KeyResult/constants'
 import { KeyResult } from 'src/components/KeyResult/types'
+import { keyResultAtomFamily } from 'src/state/recoil/key-result'
+import { keyResultChecklistAtom } from 'src/state/recoil/key-result/checklist'
 
 import { KeyResultChecklistWrapper } from '../../Sections/Checklist/wrapper'
 
@@ -21,7 +25,16 @@ export interface KeyResultDrawerBodyProperties {
 }
 
 const KeyResultDrawerBody = ({ keyResultID, isLoading }: KeyResultDrawerBodyProperties) => {
+  const keyResult = useRecoilValue(keyResultAtomFamily(keyResultID))
+  const keyResultChecklist = useRecoilValue(keyResultChecklistAtom(keyResultID))
   const timelinePortalReference = useRef<HTMLDivElement>(null)
+
+  const newCheckInValue =
+    keyResult?.format === KEY_RESULT_FORMAT.PERCENTAGE &&
+    keyResult?.initialValue === 0 &&
+    keyResult?.goal === 100
+      ? keyResultChecklist?.progress.progress
+      : undefined
 
   return (
     <Stack
@@ -39,7 +52,11 @@ const KeyResultDrawerBody = ({ keyResultID, isLoading }: KeyResultDrawerBodyProp
 
       <Portal containerRef={timelinePortalReference}>
         <Box p={8} pt={4}>
-          <KeyResultSectionTimeline keyResultID={keyResultID} scrollTarget={SCROLLBAR_ID} />
+          <KeyResultSectionTimeline
+            keyResultID={keyResultID}
+            scrollTarget={SCROLLBAR_ID}
+            newCheckInValue={newCheckInValue}
+          />
         </Box>
       </Portal>
 

--- a/src/components/KeyResult/Single/Drawer/drawer.tsx
+++ b/src/components/KeyResult/Single/Drawer/drawer.tsx
@@ -9,6 +9,7 @@ import {
   keyResultCheckInProgressDraft,
   keyResultLatestCheckIn,
 } from 'src/state/recoil/key-result/check-in'
+import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 import { keyResultReadDrawerOpenedKeyResultID } from 'src/state/recoil/key-result/drawers/read/opened-key-result-id'
 
 import KeyResultDrawerContent from './content'
@@ -22,11 +23,13 @@ const KeyResultDrawer = () => {
   const resetOpenDrawer = useResetRecoilState(keyResultReadDrawerOpenedKeyResultID)
   const resetTimeline = useResetRecoilState(timelineSelector(keyResultID))
   const resetCommentEnabled = useResetRecoilState(keyResultCheckInCommentEnabled(keyResultID))
+  const resetCheckmarkDrafts = useResetRecoilState(draftCheckMarksAtom(keyResultID))
 
   const handleClose = () => {
     resetOpenDrawer()
     resetTimeline()
     resetCommentEnabled()
+    resetCheckmarkDrafts()
     setDraftValue(latestKeyResultCheckIn?.value)
   }
 

--- a/src/components/KeyResult/Single/Drawer/queries.gql
+++ b/src/components/KeyResult/Single/Drawer/queries.gql
@@ -16,15 +16,6 @@ query GET_KEY_RESULT_WITH_ID($id: ID!) {
         create
       }
     }
-    checkList {
-      edges {
-        node {
-          id
-          description
-          state
-        }
-      }
-    }
     status {
       isOutdated
       isActive

--- a/src/components/KeyResult/Single/Drawer/queries.gql
+++ b/src/components/KeyResult/Single/Drawer/queries.gql
@@ -16,6 +16,15 @@ query GET_KEY_RESULT_WITH_ID($id: ID!) {
         create
       }
     }
+    checkList {
+      edges {
+        node {
+          id
+          description
+          state
+        }
+      }
+    }
     status {
       isOutdated
       isActive

--- a/src/components/KeyResult/Single/Sections/AddCheckIn/add-check-in.tsx
+++ b/src/components/KeyResult/Single/Sections/AddCheckIn/add-check-in.tsx
@@ -15,11 +15,13 @@ import messages from './messages'
 export interface KeyResultSectionAddCheckInProperties {
   keyResultID?: KeyResult['id']
   onCompleted?: (data: KeyResultCheckIn) => void
+  newCheckInValue?: number
 }
 
 const KeyResultSectionAddCheckIn = ({
   keyResultID,
   onCompleted,
+  newCheckInValue,
 }: KeyResultSectionAddCheckInProperties) => {
   const [isOpen, setIsOpen] = useState(false)
   const latestKeyResultCheckIn = useRecoilValue(selectLatestCheckIn(keyResultID))
@@ -71,6 +73,7 @@ const KeyResultSectionAddCheckIn = ({
             isCommentAlwaysEnabled
             keyResultID={keyResultID}
             afterSubmit={handleSubmit}
+            valueNew={newCheckInValue}
             onCompleted={onCompleted}
           />
         </KeyResultSectionTimelineCardBase>

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
@@ -7,8 +7,8 @@ import { useRecoilState } from 'recoil'
 import { PlusOutline } from 'src/components/Icon'
 import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 
-import messages from '../messages'
-import queries from '../queries.gql'
+import messages from './messages'
+import queries from './queries.gql'
 
 interface CreateCheckMarkButtonProperties {
   keyResultID?: string

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
@@ -13,32 +13,34 @@ import queries from './queries.gql'
 interface CreateCheckMarkButtonProperties {
   keyResultID?: string
   label?: string
-  refresh: () => void
+  onCreate: () => void
   createButtonReference?: Ref<HTMLButtonElement>
 }
 
 export const CreateCheckMarkButton = ({
   label,
-  refresh,
   keyResultID,
   createButtonReference,
+  onCreate,
 }: CreateCheckMarkButtonProperties) => {
   const intl = useIntl()
   const [draftCheckMarks, setDraftCheckMarks] = useRecoilState(draftCheckMarksAtom(keyResultID))
   const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
-    variables: {
-      keyResultID,
-      description: '',
-    },
     onCompleted: (data) => {
       const newDraftCheckMarks = [...draftCheckMarks, data.createKeyResultCheckMark.id]
       setDraftCheckMarks(newDraftCheckMarks)
+
+      if (onCreate) onCreate()
     },
   })
 
   const handleNewCheckMark = async () => {
-    await createCheckMark()
-    refresh()
+    await createCheckMark({
+      variables: {
+        keyResultID,
+        description: '',
+      },
+    })
   }
 
   return (

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
@@ -28,7 +28,7 @@ export const CreateCheckMarkButton = ({
   const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
     variables: {
       keyResultID,
-      description: intl.formatMessage(messages.draftCheckMarkDescription),
+      description: '',
     },
     onCompleted: (data) => {
       const newDraftCheckMarks = [...draftCheckMarks, data.createKeyResultCheckMark.id]

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
@@ -10,13 +10,17 @@ import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 import messages from '../messages'
 import queries from '../queries.gql'
 
-interface NewCheckMarkProperties {
+interface CreateCheckMarkButtonProperties {
   keyResultID?: string
   label?: string
   refresh: () => void
 }
 
-export const CreateCheckMark = ({ label, refresh, keyResultID }: NewCheckMarkProperties) => {
+export const CreateCheckMarkButton = ({
+  label,
+  refresh,
+  keyResultID,
+}: CreateCheckMarkButtonProperties) => {
   const intl = useIntl()
   const [draftCheckMarks, setDraftCheckMarks] = useRecoilState(draftCheckMarksAtom(keyResultID))
   const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
@@ -7,8 +7,8 @@ import { useRecoilState } from 'recoil'
 import { PlusOutline } from 'src/components/Icon'
 import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 
-import messages from './messages'
-import queries from './queries.gql'
+import messages from '../messages'
+import queries from '../queries.gql'
 
 interface NewCheckMarkProperties {
   keyResultID?: string
@@ -16,7 +16,7 @@ interface NewCheckMarkProperties {
   refresh: () => void
 }
 
-export const NewCheckMark = ({ label, refresh, keyResultID }: NewCheckMarkProperties) => {
+export const CreateCheckMark = ({ label, refresh, keyResultID }: NewCheckMarkProperties) => {
   const intl = useIntl()
   const [draftCheckMarks, setDraftCheckMarks] = useRecoilState(draftCheckMarksAtom(keyResultID))
   const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-checkmark.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client'
 import { Button } from '@chakra-ui/react'
-import React from 'react'
+import React, { Ref } from 'react'
 import { useIntl } from 'react-intl'
 import { useRecoilState } from 'recoil'
 
@@ -14,12 +14,14 @@ interface CreateCheckMarkButtonProperties {
   keyResultID?: string
   label?: string
   refresh: () => void
+  createButtonReference?: Ref<HTMLButtonElement>
 }
 
 export const CreateCheckMarkButton = ({
   label,
   refresh,
   keyResultID,
+  createButtonReference,
 }: CreateCheckMarkButtonProperties) => {
   const intl = useIntl()
   const [draftCheckMarks, setDraftCheckMarks] = useRecoilState(draftCheckMarksAtom(keyResultID))
@@ -41,6 +43,7 @@ export const CreateCheckMarkButton = ({
 
   return (
     <Button
+      ref={createButtonReference}
       variant="text"
       p={0}
       h="auto"

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -12,7 +12,7 @@ import queries from './queries.gql'
 
 interface DeleteCheckMarkButtonProperties {
   checkMarkID?: string
-  refresh?: () => void
+  onDelete?: () => void
   isVisible?: boolean
   canDelete?: boolean
   buttonRef?: Ref<HTMLButtonElement>
@@ -20,7 +20,7 @@ interface DeleteCheckMarkButtonProperties {
 
 export const DeleteCheckMarkButton = ({
   checkMarkID,
-  refresh,
+  onDelete: refresh,
   isVisible,
   canDelete,
   buttonRef,

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -14,12 +14,14 @@ interface DeleteCheckMarkButtonProperties {
   checkMarkID?: string
   refresh?: () => void
   isVisible?: boolean
+  canDelete?: boolean
 }
 
 export const DeleteCheckMarkButton = ({
   checkMarkID,
   refresh,
   isVisible,
+  canDelete,
 }: DeleteCheckMarkButtonProperties) => {
   isVisible ??= true
 
@@ -37,7 +39,7 @@ export const DeleteCheckMarkButton = ({
     if (refresh) refresh()
   }
 
-  return isVisible ? (
+  return canDelete && isVisible ? (
     <IconButton
       aria-label={intl.formatMessage(messages.removeIconDescription)}
       bg="new-gray.600"

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -51,7 +51,7 @@ export const DeleteCheckMarkButton = ({
       minW="auto"
       p={1}
       _hover={{ bg: 'new-gray.800' }}
-      display={isVisible ? 'inherit' : 'none'}
+      opacity={isVisible ? 1 : 0}
       icon={
         <TimesIcon
           desc={intl.formatMessage(messages.removeIconDescription)}

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client'
 import { IconButton } from '@chakra-ui/react'
-import React from 'react'
+import React, { Ref } from 'react'
 import { useIntl } from 'react-intl'
 import { useSetRecoilState } from 'recoil'
 
@@ -15,6 +15,7 @@ interface DeleteCheckMarkButtonProperties {
   refresh?: () => void
   isVisible?: boolean
   canDelete?: boolean
+  buttonRef?: Ref<HTMLButtonElement>
 }
 
 export const DeleteCheckMarkButton = ({
@@ -22,6 +23,7 @@ export const DeleteCheckMarkButton = ({
   refresh,
   isVisible,
   canDelete,
+  buttonRef,
 }: DeleteCheckMarkButtonProperties) => {
   isVisible ??= true
 
@@ -39,8 +41,9 @@ export const DeleteCheckMarkButton = ({
     if (refresh) refresh()
   }
 
-  return canDelete && isVisible ? (
+  return canDelete ? (
     <IconButton
+      ref={buttonRef}
       aria-label={intl.formatMessage(messages.removeIconDescription)}
       bg="new-gray.600"
       borderRadius="full"
@@ -48,6 +51,7 @@ export const DeleteCheckMarkButton = ({
       minW="auto"
       p={1}
       _hover={{ bg: 'new-gray.800' }}
+      display={isVisible ? 'inherit' : 'none'}
       icon={
         <TimesIcon
           desc={intl.formatMessage(messages.removeIconDescription)}

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface DeleteCheckMarkButtonProperties {
+  keyResultID?: string
+  refresh?: () => void
+  isVisible?: boolean
+}
+
+export const DeleteCheckMarkButton = ({
+  keyResultID,
+  refresh,
+  isVisible,
+}: DeleteCheckMarkButtonProperties) => {
+  isVisible ??= true
+
+  // eslint-disable-next-line unicorn/no-null
+  return isVisible ? <p>Ok</p> : null
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@apollo/client'
 import { IconButton } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
@@ -5,21 +6,32 @@ import { useIntl } from 'react-intl'
 import TimesIcon from 'src/components/Icon/Times'
 
 import messages from './messages'
+import queries from './queries.gql'
 
 interface DeleteCheckMarkButtonProperties {
-  keyResultID?: string
+  checkMarkID?: string
   refresh?: () => void
   isVisible?: boolean
 }
 
 export const DeleteCheckMarkButton = ({
-  keyResultID,
+  checkMarkID,
   refresh,
   isVisible,
 }: DeleteCheckMarkButtonProperties) => {
   isVisible ??= true
 
   const intl = useIntl()
+  const [deleteCheckmark] = useMutation(queries.DELETE_CHECK_MARK, {
+    variables: {
+      id: checkMarkID,
+    },
+  })
+
+  const handleDelete = async () => {
+    await deleteCheckmark()
+    if (refresh) refresh()
+  }
 
   return isVisible ? (
     <IconButton
@@ -38,6 +50,7 @@ export const DeleteCheckMarkButton = ({
           fontSize="xs"
         />
       }
+      onClick={handleDelete}
     />
   ) : // eslint-disable-next-line unicorn/no-null
   null

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -2,8 +2,10 @@ import { useMutation } from '@apollo/client'
 import { IconButton } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
+import { useSetRecoilState } from 'recoil'
 
 import TimesIcon from 'src/components/Icon/Times'
+import { checkMarkIsBeingRemovedAtom } from 'src/state/recoil/key-result/checklist'
 
 import messages from './messages'
 import queries from './queries.gql'
@@ -22,6 +24,7 @@ export const DeleteCheckMarkButton = ({
   isVisible ??= true
 
   const intl = useIntl()
+  const setCheckMarkIsBeingRemoved = useSetRecoilState(checkMarkIsBeingRemovedAtom(checkMarkID))
   const [deleteCheckmark] = useMutation(queries.DELETE_CHECK_MARK, {
     variables: {
       id: checkMarkID,
@@ -29,6 +32,7 @@ export const DeleteCheckMarkButton = ({
   })
 
   const handleDelete = async () => {
+    setCheckMarkIsBeingRemoved(true)
     await deleteCheckmark()
     if (refresh) refresh()
   }

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/delete-checkmark.tsx
@@ -1,4 +1,10 @@
+import { IconButton } from '@chakra-ui/react'
 import React from 'react'
+import { useIntl } from 'react-intl'
+
+import TimesIcon from 'src/components/Icon/Times'
+
+import messages from './messages'
 
 interface DeleteCheckMarkButtonProperties {
   keyResultID?: string
@@ -13,6 +19,26 @@ export const DeleteCheckMarkButton = ({
 }: DeleteCheckMarkButtonProperties) => {
   isVisible ??= true
 
-  // eslint-disable-next-line unicorn/no-null
-  return isVisible ? <p>Ok</p> : null
+  const intl = useIntl()
+
+  return isVisible ? (
+    <IconButton
+      aria-label={intl.formatMessage(messages.removeIconDescription)}
+      bg="new-gray.600"
+      borderRadius="full"
+      h="auto"
+      minW="auto"
+      p={1}
+      _hover={{ bg: 'new-gray.800' }}
+      icon={
+        <TimesIcon
+          desc={intl.formatMessage(messages.removeIconDescription)}
+          fill="white"
+          stroke="white"
+          fontSize="xs"
+        />
+      }
+    />
+  ) : // eslint-disable-next-line unicorn/no-null
+  null
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/messages.ts
@@ -1,0 +1,36 @@
+import { defineMessages } from 'react-intl'
+
+type ActionButtonsMessages =
+  | 'removeIconDescription'
+  | 'newCheckMarkButtonLabel'
+  | 'newCheckMarkButtonIconDescription'
+  | 'draftCheckMarkDescription'
+
+export default defineMessages<ActionButtonsMessages>({
+  removeIconDescription: {
+    defaultMessage: 'Um ícone de "x". Ao clicar nele você irá remover esse item da checklist',
+    id: 'sSCvSb',
+    description:
+      'This text is used by screen readers inside our key-result drawer to describe the X icon to remove a given item from the checklist',
+  },
+
+  newCheckMarkButtonLabel: {
+    defaultMessage: 'Adicionar novo item',
+    id: 'zennqC',
+    description: 'This label appears in our key-result sidebar drawer, in the end of our checklist',
+  },
+
+  newCheckMarkButtonIconDescription: {
+    defaultMessage:
+      'Um ícone do sinal de positivo que, ao clicar, irá adicionar um novo item na checklist',
+    id: 'e2FL3I',
+    description:
+      'This is used by screen readers to understand the insert new check mark icon in our key-result drawer',
+  },
+
+  draftCheckMarkDescription: {
+    defaultMessage: 'Novo item',
+    id: 'qYpqgw',
+    description: 'This is the description used as default by a check mark when we add a new item',
+  },
+})

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/messages.ts
@@ -4,7 +4,6 @@ type ActionButtonsMessages =
   | 'removeIconDescription'
   | 'newCheckMarkButtonLabel'
   | 'newCheckMarkButtonIconDescription'
-  | 'draftCheckMarkDescription'
 
 export default defineMessages<ActionButtonsMessages>({
   removeIconDescription: {
@@ -26,11 +25,5 @@ export default defineMessages<ActionButtonsMessages>({
     id: 'e2FL3I',
     description:
       'This is used by screen readers to understand the insert new check mark icon in our key-result drawer',
-  },
-
-  draftCheckMarkDescription: {
-    defaultMessage: 'Novo item',
-    id: 'qYpqgw',
-    description: 'This is the description used as default by a check mark when we add a new item',
   },
 })

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/queries.gql
@@ -8,3 +8,9 @@ mutation CREATE_CHECK_MARK($keyResultID: ID!, $description: String!) {
     }
   }
 }
+
+mutation DELETE_CHECK_MARK($id: ID!) {
+  deleteCheckMark(id: $id) {
+    affected
+  }
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/queries.gql
@@ -1,0 +1,10 @@
+mutation CREATE_CHECK_MARK($keyResultID: ID!, $description: String!) {
+  createKeyResultCheckMark(data: { keyResultId: $keyResultID, description: $description }) {
+    id
+    description
+    state
+    policy {
+      update
+    }
+  }
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
@@ -1,9 +1,26 @@
+import { Flex } from '@chakra-ui/react'
 import React from 'react'
+import { useIntl } from 'react-intl'
 
-import { KeyResultChecklistProgress } from 'src/components/KeyResult/types'
+import { NewCheckMark } from '../new-checkmark'
+
+import messages from './messages'
 
 interface EmptyChecklistProperties {
-  progress?: KeyResultChecklistProgress
+  refresh: () => void
+  keyResultID?: string
 }
 
-export const EmptyChecklist = ({ progress }: EmptyChecklistProperties) => <p>Empty</p>
+export const EmptyChecklist = ({ keyResultID, refresh }: EmptyChecklistProperties) => {
+  const intl = useIntl()
+
+  return (
+    <Flex flexGrow={1} justifyContent="flex-end">
+      <NewCheckMark
+        refresh={refresh}
+        keyResultID={keyResultID}
+        label={intl.formatMessage(messages.newChecklistButtonLabel)}
+      />
+    </Flex>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import { KeyResultChecklistProgress } from 'src/components/KeyResult/types'
+
+interface EmptyChecklistProperties {
+  progress?: KeyResultChecklistProgress
+}
+
+export const EmptyChecklist = ({ progress }: EmptyChecklistProperties) => <p>Empty</p>

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
-import { CreateCheckMark } from '../ActionButtons/create-checkmark'
+import { CreateCheckMarkButton } from '../ActionButtons/create-checkmark'
 
 import messages from './messages'
 
@@ -18,7 +18,7 @@ export const EmptyChecklist = ({ keyResultID, refresh, canCreate }: EmptyCheckli
   return (
     <Flex flexGrow={1} justifyContent="flex-end">
       {canCreate && (
-        <CreateCheckMark
+        <CreateCheckMarkButton
           refresh={refresh}
           keyResultID={keyResultID}
           label={intl.formatMessage(messages.newChecklistButtonLabel)}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
@@ -8,19 +8,22 @@ import messages from './messages'
 
 interface EmptyChecklistProperties {
   refresh: () => void
+  canCreate: boolean
   keyResultID?: string
 }
 
-export const EmptyChecklist = ({ keyResultID, refresh }: EmptyChecklistProperties) => {
+export const EmptyChecklist = ({ keyResultID, refresh, canCreate }: EmptyChecklistProperties) => {
   const intl = useIntl()
 
   return (
     <Flex flexGrow={1} justifyContent="flex-end">
-      <NewCheckMark
-        refresh={refresh}
-        keyResultID={keyResultID}
-        label={intl.formatMessage(messages.newChecklistButtonLabel)}
-      />
+      {canCreate && (
+        <NewCheckMark
+          refresh={refresh}
+          keyResultID={keyResultID}
+          label={intl.formatMessage(messages.newChecklistButtonLabel)}
+        />
+      )}
     </Flex>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
@@ -7,21 +7,21 @@ import { CreateCheckMarkButton } from '../ActionButtons/create-checkmark'
 import messages from './messages'
 
 interface EmptyChecklistProperties {
-  refresh: () => void
+  onCreate: () => void
   canCreate: boolean
   keyResultID?: string
 }
 
-export const EmptyChecklist = ({ keyResultID, refresh, canCreate }: EmptyChecklistProperties) => {
+export const EmptyChecklist = ({ keyResultID, canCreate, onCreate }: EmptyChecklistProperties) => {
   const intl = useIntl()
 
   return (
     <Flex flexGrow={1} justifyContent="flex-end">
       {canCreate && (
         <CreateCheckMarkButton
-          refresh={refresh}
           keyResultID={keyResultID}
           label={intl.formatMessage(messages.newChecklistButtonLabel)}
+          onCreate={onCreate}
         />
       )}
     </Flex>

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/empty-checklist.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
-import { NewCheckMark } from '../new-checkmark'
+import { CreateCheckMark } from '../ActionButtons/create-checkmark'
 
 import messages from './messages'
 
@@ -18,7 +18,7 @@ export const EmptyChecklist = ({ keyResultID, refresh, canCreate }: EmptyCheckli
   return (
     <Flex flexGrow={1} justifyContent="flex-end">
       {canCreate && (
-        <NewCheckMark
+        <CreateCheckMark
           refresh={refresh}
           keyResultID={keyResultID}
           label={intl.formatMessage(messages.newChecklistButtonLabel)}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/messages.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl'
 
-type OptionBarMessages = 'completed' | 'checkIconDescription'
+type OptionBarMessages = 'completed' | 'checkIconDescription' | 'newChecklistButtonLabel'
 
 export default defineMessages<OptionBarMessages>({
   completed: {
@@ -16,5 +16,11 @@ export default defineMessages<OptionBarMessages>({
     id: 'W37c+K',
     description:
       'This text is used by screen readers to explain the check icon in our key-result drawer checklist section',
+  },
+
+  newChecklistButtonLabel: {
+    defaultMessage: 'Adicionar uma Check-list',
+    id: 's4h8ne',
+    description: 'This text is used as a button when the key-result has no check-marks',
   },
 })

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/messages.ts
@@ -1,0 +1,20 @@
+import { defineMessages } from 'react-intl'
+
+type OptionBarMessages = 'completed' | 'checkIconDescription'
+
+export default defineMessages<OptionBarMessages>({
+  completed: {
+    defaultMessage: '{completed}/{total}',
+    id: 'O13rH5',
+    description:
+      'This messages is displayed in our our key-result drawer above the checklist as the count of total completed checkmarks',
+  },
+
+  checkIconDescription: {
+    defaultMessage:
+      'Um ícone de check. Ele representa a quantidade de itens marcados como completo em sua checklist',
+    id: 'W37c+K',
+    description:
+      'This text is used by screen readers to explain the check icon in our key-result drawer checklist section',
+  },
+})

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
@@ -2,7 +2,9 @@ import { Flex, Skeleton, Stack, Text } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
+import { SliderWithFilledTrack } from 'src/components/Base'
 import CheckIcon from 'src/components/Icon/Check'
+import { PercentageNumberMask } from 'src/components/KeyResult/NumberMasks'
 import { KeyResultChecklistProgress } from 'src/components/KeyResult/types'
 
 import messages from './messages'
@@ -15,22 +17,35 @@ export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => 
   const intl = useIntl()
 
   return (
-    <Stack direction="row" spacing={2} alignItems="center">
-      <Flex bg="brand.100" borderRadius="full" w={4} h={4}>
-        <CheckIcon
-          desc={intl.formatMessage(messages.checkIconDescription)}
-          fill="brand.500"
-          stroke="brand.500"
-        />
-      </Flex>
-      <Skeleton isLoaded={Boolean(progress)}>
-        <Text color="brand.500" fontSize="sm" fontWeight={500}>
-          {intl.formatMessage(messages.completed, {
-            completed: progress?.numberOfChecked ?? 0,
-            total: progress?.total ?? 0,
-          })}
-        </Text>
-      </Skeleton>
+    <Stack direction="row" alignItems="center" flexGrow={1} spacing={2}>
+      <Stack direction="row" spacing={2} alignItems="center" flexGrow={1}>
+        <Flex bg="brand.100" borderRadius="full" w={4} h={4}>
+          <CheckIcon
+            desc={intl.formatMessage(messages.checkIconDescription)}
+            fill="brand.500"
+            stroke="brand.500"
+          />
+        </Flex>
+        <Skeleton isLoaded={Boolean(progress)}>
+          <Text color="brand.500" fontSize="sm" fontWeight={500}>
+            {intl.formatMessage(messages.completed, {
+              completed: progress?.numberOfChecked ?? 0,
+              total: progress?.total ?? 0,
+            })}
+          </Text>
+        </Skeleton>
+      </Stack>
+
+      <Stack
+        direction="row"
+        alignItems="center"
+        fontSize="sm"
+        fontWeight={700}
+        color="new-gray.800"
+      >
+        <SliderWithFilledTrack value={progress?.progress ?? 0} minW={24} />
+        <PercentageNumberMask displayType="text" value={progress?.progress ?? 0} />
+      </Stack>
     </Stack>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
@@ -44,10 +44,8 @@ export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => 
         fontWeight={700}
         color="new-gray.800"
       >
-        <Skeleton isLoaded={isLoaded}>
-          <Flex>
-            <SliderWithFilledTrack value={progress?.progress ?? 0} minW={24} />
-          </Flex>
+        <Skeleton isLoaded={isLoaded} display="flex" minH={4}>
+          <SliderWithFilledTrack value={progress?.progress ?? 0} minW={24} />
         </Skeleton>
 
         <Skeleton isLoaded={isLoaded}>

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
@@ -1,9 +1,36 @@
+import { Flex, Skeleton, Stack, Text } from '@chakra-ui/react'
 import React from 'react'
+import { useIntl } from 'react-intl'
 
+import CheckIcon from 'src/components/Icon/Check'
 import { KeyResultChecklistProgress } from 'src/components/KeyResult/types'
+
+import messages from './messages'
 
 interface NonEmptyChecklistProperties {
   progress?: KeyResultChecklistProgress
 }
 
-export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => <p>Non Empty</p>
+export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => {
+  const intl = useIntl()
+
+  return (
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Flex bg="brand.100" borderRadius="full" w={4} h={4}>
+        <CheckIcon
+          desc={intl.formatMessage(messages.checkIconDescription)}
+          fill="brand.500"
+          stroke="brand.500"
+        />
+      </Flex>
+      <Skeleton isLoaded={Boolean(progress)}>
+        <Text color="brand.500" fontSize="sm" fontWeight={500}>
+          {intl.formatMessage(messages.completed, {
+            completed: progress?.numberOfChecked ?? 0,
+            total: progress?.total ?? 0,
+          })}
+        </Text>
+      </Skeleton>
+    </Stack>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import { KeyResultChecklistProgress } from 'src/components/KeyResult/types'
+
+interface NonEmptyChecklistProperties {
+  progress?: KeyResultChecklistProgress
+}
+
+export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => <p>Non Empty</p>

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/non-empty-checklist.tsx
@@ -15,6 +15,7 @@ interface NonEmptyChecklistProperties {
 
 export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => {
   const intl = useIntl()
+  const isLoaded = Boolean(progress)
 
   return (
     <Stack direction="row" alignItems="center" flexGrow={1} spacing={2}>
@@ -26,7 +27,7 @@ export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => 
             stroke="brand.500"
           />
         </Flex>
-        <Skeleton isLoaded={Boolean(progress)}>
+        <Skeleton isLoaded={isLoaded}>
           <Text color="brand.500" fontSize="sm" fontWeight={500}>
             {intl.formatMessage(messages.completed, {
               completed: progress?.numberOfChecked ?? 0,
@@ -43,8 +44,15 @@ export const NonEmptyChecklist = ({ progress }: NonEmptyChecklistProperties) => 
         fontWeight={700}
         color="new-gray.800"
       >
-        <SliderWithFilledTrack value={progress?.progress ?? 0} minW={24} />
-        <PercentageNumberMask displayType="text" value={progress?.progress ?? 0} />
+        <Skeleton isLoaded={isLoaded}>
+          <Flex>
+            <SliderWithFilledTrack value={progress?.progress ?? 0} minW={24} />
+          </Flex>
+        </Skeleton>
+
+        <Skeleton isLoaded={isLoaded}>
+          <PercentageNumberMask displayType="text" value={progress?.progress ?? 0} />
+        </Skeleton>
       </Stack>
     </Stack>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
@@ -9,17 +9,19 @@ import { NonEmptyChecklist } from './non-empty-checklist'
 interface OptionBarWrapperProperties {
   progress?: KeyResultChecklistProgress
   keyResultID?: string
+  canCreate: boolean
   refresh: () => void
 }
 
 export const OptionBarWrapper = ({
   progress,
   keyResultID,
+  canCreate,
   refresh,
 }: OptionBarWrapperProperties) => (
   <Stack direction="row" flexGrow={1}>
     {progress && progress.total === 0 ? (
-      <EmptyChecklist keyResultID={keyResultID} refresh={refresh} />
+      <EmptyChecklist keyResultID={keyResultID} refresh={refresh} canCreate={canCreate} />
     ) : (
       <NonEmptyChecklist progress={progress} />
     )}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
@@ -8,12 +8,18 @@ import { NonEmptyChecklist } from './non-empty-checklist'
 
 interface OptionBarWrapperProperties {
   progress?: KeyResultChecklistProgress
+  keyResultID?: string
+  refresh: () => void
 }
 
-export const OptionBarWrapper = ({ progress }: OptionBarWrapperProperties) => (
+export const OptionBarWrapper = ({
+  progress,
+  keyResultID,
+  refresh,
+}: OptionBarWrapperProperties) => (
   <Stack direction="row" flexGrow={1}>
     {progress && progress.total === 0 ? (
-      <EmptyChecklist progress={progress} />
+      <EmptyChecklist keyResultID={keyResultID} refresh={refresh} />
     ) : (
       <NonEmptyChecklist progress={progress} />
     )}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
@@ -10,18 +10,18 @@ interface OptionBarWrapperProperties {
   progress?: KeyResultChecklistProgress
   keyResultID?: string
   canCreate: boolean
-  refresh: () => void
+  onCreate: () => void
 }
 
 export const OptionBarWrapper = ({
   progress,
   keyResultID,
   canCreate,
-  refresh,
+  onCreate,
 }: OptionBarWrapperProperties) => (
   <Stack direction="row" flexGrow={1}>
     {progress && progress.total === 0 ? (
-      <EmptyChecklist keyResultID={keyResultID} refresh={refresh} canCreate={canCreate} />
+      <EmptyChecklist keyResultID={keyResultID} canCreate={canCreate} onCreate={onCreate} />
     ) : (
       <NonEmptyChecklist progress={progress} />
     )}

--- a/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/OptionBar/wrapper.tsx
@@ -1,0 +1,21 @@
+import { Stack } from '@chakra-ui/react'
+import React from 'react'
+
+import { KeyResultChecklistProgress } from 'src/components/KeyResult/types'
+
+import { EmptyChecklist } from './empty-checklist'
+import { NonEmptyChecklist } from './non-empty-checklist'
+
+interface OptionBarWrapperProperties {
+  progress?: KeyResultChecklistProgress
+}
+
+export const OptionBarWrapper = ({ progress }: OptionBarWrapperProperties) => (
+  <Stack direction="row" flexGrow={1}>
+    {progress && progress.total === 0 ? (
+      <EmptyChecklist progress={progress} />
+    ) : (
+      <NonEmptyChecklist progress={progress} />
+    )}
+  </Stack>
+)

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client'
-import { HStack, Checkbox, Skeleton } from '@chakra-ui/react'
+import { HStack, Checkbox, Skeleton, Box } from '@chakra-ui/react'
 import React, { useEffect, useRef, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
@@ -119,12 +119,18 @@ export const KeyResultCheckMark = ({
 
   return (
     <Skeleton isLoaded={isLoaded} w="full" fadeDuration={0}>
-      <HStack alignItems="center" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-        <Checkbox
-          isChecked={isChecked}
-          isDisabled={isWaiting || !canUpdate}
-          onChange={handleChange}
-        />
+      <HStack
+        alignItems="flex-start"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <Box py={1}>
+          <Checkbox
+            isChecked={isChecked}
+            isDisabled={isWaiting || !canUpdate}
+            onChange={handleChange}
+          />
+        </Box>
         <EditableInputField
           autoFocus={isDraft}
           isWaiting={isWaiting}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -32,6 +32,7 @@ export const KeyResultCheckMark = ({
   onCreate,
 }: KeyResultCheckMarkProperties) => {
   const [isHovering, setIsHovering] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
   const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
   const checkmarkIsBeingRemoved = useRecoilValue(checkMarkIsBeingRemovedAtom(node?.id))
   const removeCheckmarkButton = useRef<HTMLButtonElement>(null)
@@ -91,6 +92,14 @@ export const KeyResultCheckMark = ({
     if (index && checklistLength && index === checklistLength - 1 && onCreate) onCreate()
   }
 
+  const handleStartEdit = () => {
+    setIsEditing(true)
+  }
+
+  const handleStopEdit = () => {
+    setIsEditing(false)
+  }
+
   useEffect(() => {
     setIsChecked(node?.state === KeyResultCheckMarkState.CHECKED)
   }, [node?.state, setIsChecked])
@@ -112,12 +121,14 @@ export const KeyResultCheckMark = ({
           isDisabled={!canUpdate}
           onSubmit={handleNewCheckMarkDescription}
           onPressedEnter={handleEnterKey}
+          onStartEdit={handleStartEdit}
+          onStopEdit={handleStopEdit}
         />
         <DeleteCheckMarkButton
           buttonRef={removeCheckmarkButton}
           checkMarkID={node?.id}
           refresh={refresh}
-          isVisible={isHovering}
+          isVisible={isHovering && !isEditing}
           canDelete={canDelete}
         />
       </HStack>

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -113,6 +113,7 @@ export const KeyResultCheckMark = ({
           onChange={handleChange}
         />
         <EditableInputField
+          showControls
           autoFocus={isDraft}
           isWaiting={isWaiting}
           value={node?.description}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client'
 import { HStack, Checkbox, Skeleton } from '@chakra-ui/react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
 import { EditableInputField } from 'src/components/Base'
@@ -34,6 +34,7 @@ export const KeyResultCheckMark = ({
   const [isHovering, setIsHovering] = useState(false)
   const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
   const checkmarkIsBeingRemoved = useRecoilValue(checkMarkIsBeingRemovedAtom(node?.id))
+  const removeCheckmarkButton = useRef<HTMLButtonElement>(null)
 
   const [toggleCheckMark, { loading: isToggling }] = useMutation(queries.TOGGLE_CHECK_MARK, {
     variables: {
@@ -65,7 +66,11 @@ export const KeyResultCheckMark = ({
   }
 
   const handleNewCheckMarkDescription = async (description: string) => {
-    if (node?.description !== description)
+    const isEmpty = !description || description.trim() === ''
+
+    if (isEmpty) removeCheckmarkButton.current?.click()
+
+    if (!isEmpty && node?.description !== description)
       await updateCheckMarkDescription({
         variables: {
           id: node?.id,
@@ -109,6 +114,7 @@ export const KeyResultCheckMark = ({
           onPressedEnter={handleEnterKey}
         />
         <DeleteCheckMarkButton
+          buttonRef={removeCheckmarkButton}
           checkMarkID={node?.id}
           refresh={refresh}
           isVisible={isHovering}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -7,6 +7,7 @@ import {
   KeyResultCheckMark as KeyResultCheckMarkType,
   KeyResultCheckMarkState,
 } from 'src/components/KeyResult/types'
+import { GraphQLEffect } from 'src/components/types'
 
 import queries from './queries.gql'
 
@@ -33,6 +34,7 @@ export const KeyResultCheckMark = ({
 
   const isLoaded = Boolean(node)
   const isDraft = typeof node?.id === 'undefined' ? false : draftCheckMarks?.includes(node.id)
+  const canUpdate = node?.policy?.update === GraphQLEffect.ALLOW
   const handleChange = async () => {
     await toggleCheckMark()
     if (refresh) refresh()
@@ -45,7 +47,11 @@ export const KeyResultCheckMark = ({
   return (
     <Skeleton isLoaded={isLoaded} w="full" fadeDuration={0}>
       <Stack direction="row" alignItems="center">
-        <Checkbox isChecked={isChecked} isDisabled={loading} onChange={handleChange} />
+        <Checkbox
+          isChecked={isChecked}
+          isDisabled={loading || !canUpdate}
+          onChange={handleChange}
+        />
         <EditableInputField
           autoFocus={isDraft}
           isWaiting={loading}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -80,6 +80,11 @@ export const KeyResultCheckMark = ({
       })
   }
 
+  const handleCancelDescription = (oldDescription?: string) => {
+    const isEmpty = !oldDescription || oldDescription.trim() === ''
+    if (isEmpty) removeCheckmarkButton.current?.click()
+  }
+
   const handleMouseEnter = () => {
     if (!isHovering) setIsHovering(true)
   }
@@ -120,6 +125,7 @@ export const KeyResultCheckMark = ({
           startWithEditView={isDraft}
           isDisabled={!canUpdate}
           onSubmit={handleNewCheckMarkDescription}
+          onCancel={handleCancelDescription}
           onPressedEnter={handleEnterKey}
           onStartEdit={handleStartEdit}
           onStopEdit={handleStopEdit}
@@ -127,9 +133,9 @@ export const KeyResultCheckMark = ({
         <DeleteCheckMarkButton
           buttonRef={removeCheckmarkButton}
           checkMarkID={node?.id}
-          refresh={onUpdate}
           isVisible={isHovering && !isEditing}
           canDelete={canDelete}
+          onDelete={onUpdate}
         />
       </HStack>
     </Skeleton>

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client'
-import { HStack, Checkbox, Skeleton, Box } from '@chakra-ui/react'
+import { HStack, Checkbox, Skeleton, Box, EditablePreviewProps } from '@chakra-ui/react'
 import React, { useEffect, useRef, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
@@ -113,6 +113,11 @@ export const KeyResultCheckMark = ({
     setIsEditing(false)
   }
 
+  const checkedProperties: EditablePreviewProps = {
+    color: 'new-gray.600',
+    textDecoration: 'line-through',
+  }
+
   useEffect(() => {
     setIsChecked(node?.state === KeyResultCheckMarkState.CHECKED)
   }, [node?.state, setIsChecked])
@@ -138,6 +143,7 @@ export const KeyResultCheckMark = ({
           isLoaded={isLoaded}
           startWithEditView={isDraft}
           isDisabled={!canUpdate}
+          previewProperties={isChecked ? checkedProperties : undefined}
           onSubmit={handleNewCheckMarkDescription}
           onCancel={handleCancelDescription}
           onPressedEnter={handleEnterKey}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -40,7 +40,9 @@ export const KeyResultCheckMark = ({
   const isLoaded = Boolean(node)
   const isDraft = typeof node?.id === 'undefined' ? false : draftCheckMarks?.includes(node.id)
   const isWaiting = loading || checkmarkIsBeingRemoved
+
   const canUpdate = node?.policy?.update === GraphQLEffect.ALLOW
+  const canDelete = node?.policy?.delete === GraphQLEffect.ALLOW
 
   const handleChange = async () => {
     await toggleCheckMark()
@@ -74,7 +76,12 @@ export const KeyResultCheckMark = ({
           isLoaded={isLoaded}
           startWithEditView={isDraft}
         />
-        <DeleteCheckMarkButton checkMarkID={node?.id} refresh={refresh} isVisible={isHovering} />
+        <DeleteCheckMarkButton
+          checkMarkID={node?.id}
+          refresh={refresh}
+          isVisible={isHovering}
+          canDelete={canDelete}
+        />
       </HStack>
     </Skeleton>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client'
 import { HStack, Checkbox, Skeleton } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
+import { useRecoilValue } from 'recoil'
 
 import { EditableInputField } from 'src/components/Base'
 import {
@@ -8,6 +9,7 @@ import {
   KeyResultCheckMarkState,
 } from 'src/components/KeyResult/types'
 import { GraphQLEffect } from 'src/components/types'
+import { checkMarkIsBeingRemovedAtom } from 'src/state/recoil/key-result/checklist'
 
 import { DeleteCheckMarkButton } from './ActionButtons/delete-checkmark'
 import queries from './queries.gql'
@@ -25,6 +27,7 @@ export const KeyResultCheckMark = ({
 }: KeyResultCheckMarkProperties) => {
   const [isHovering, setIsHovering] = useState(false)
   const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
+  const checkmarkIsBeingRemoved = useRecoilValue(checkMarkIsBeingRemovedAtom(node?.id))
   const [toggleCheckMark, { loading }] = useMutation(queries.TOGGLE_CHECK_MARK, {
     variables: {
       id: node?.id,
@@ -36,6 +39,7 @@ export const KeyResultCheckMark = ({
 
   const isLoaded = Boolean(node)
   const isDraft = typeof node?.id === 'undefined' ? false : draftCheckMarks?.includes(node.id)
+  const isWaiting = loading || checkmarkIsBeingRemoved
   const canUpdate = node?.policy?.update === GraphQLEffect.ALLOW
 
   const handleChange = async () => {
@@ -60,12 +64,12 @@ export const KeyResultCheckMark = ({
       <HStack alignItems="center" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <Checkbox
           isChecked={isChecked}
-          isDisabled={loading || !canUpdate}
+          isDisabled={isWaiting || !canUpdate}
           onChange={handleChange}
         />
         <EditableInputField
           autoFocus={isDraft}
-          isWaiting={loading}
+          isWaiting={isWaiting}
           value={node?.description}
           isLoaded={isLoaded}
           startWithEditView={isDraft}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -94,6 +94,7 @@ export const KeyResultCheckMark = ({
           value={node?.description}
           isLoaded={isLoaded}
           startWithEditView={isDraft}
+          isDisabled={!canUpdate}
           onSubmit={handleNewCheckMarkDescription}
         />
         <DeleteCheckMarkButton

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@apollo/client'
 import {
   Checkbox,
   Stack,
@@ -6,18 +7,43 @@ import {
   EditableInput,
   Skeleton,
 } from '@chakra-ui/react'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { KeyResultCheckMark as KeyResultCheckMarkType } from '../../../../../components/KeyResult/types'
+import {
+  KeyResultCheckMark as KeyResultCheckMarkType,
+  KeyResultCheckMarkState,
+} from '../../../../../components/KeyResult/types'
 
-export const KeyResultCheckMark = ({ id, description }: Partial<KeyResultCheckMarkType>) => (
-  <Skeleton isLoaded={Boolean(id)} w="full">
-    <Stack direction="row" alignItems="center">
-      <Checkbox />
-      <Editable value={description} w="full">
-        <EditablePreview />
-        <EditableInput />
-      </Editable>
-    </Stack>
-  </Skeleton>
-)
+import queries from './queries.gql'
+
+export const KeyResultCheckMark = ({ id, description, state }: Partial<KeyResultCheckMarkType>) => {
+  const [isChecked, setIsChecked] = useState(state === KeyResultCheckMarkState.CHECKED)
+  const [toggleCheckMark] = useMutation(queries.TOGGLE_CHECK_MARK, {
+    variables: {
+      id,
+    },
+    onCompleted: (data) => {
+      setIsChecked(data.toggleCheckMark.state === KeyResultCheckMarkState.CHECKED)
+    },
+  })
+
+  const handleChange = async () => {
+    void toggleCheckMark()
+  }
+
+  useEffect(() => {
+    setIsChecked(state === KeyResultCheckMarkState.CHECKED)
+  }, [state, setIsChecked])
+
+  return (
+    <Skeleton isLoaded={Boolean(id)} w="full">
+      <Stack direction="row" alignItems="center">
+        <Checkbox isChecked={isChecked} onChange={handleChange} />
+        <Editable value={description} w="full">
+          <EditablePreview />
+          <EditableInput />
+        </Editable>
+      </Stack>
+    </Skeleton>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -47,6 +47,7 @@ export const KeyResultCheckMark = ({
       <Stack direction="row" alignItems="center">
         <Checkbox isChecked={isChecked} isDisabled={loading} onChange={handleChange} />
         <EditableInputField
+          autoFocus={isDraft}
           isWaiting={loading}
           value={node?.description}
           isLoaded={isLoaded}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,8 +1,10 @@
-import { Checkbox } from '@chakra-ui/react'
+import { Checkbox, Skeleton } from '@chakra-ui/react'
 import React from 'react'
 
 import { KeyResultCheckMark as KeyResultCheckMarkType } from '../../../../../components/KeyResult/types'
 
-export const KeyResultCheckMark = ({ id, description }: KeyResultCheckMarkType) => (
-  <Checkbox>{description}</Checkbox>
+export const KeyResultCheckMark = ({ id, description }: Partial<KeyResultCheckMarkType>) => (
+  <Skeleton isLoaded={Boolean(id)}>
+    <Checkbox>{description}</Checkbox>
+  </Skeleton>
 )

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -3,38 +3,44 @@ import { Checkbox, Stack, Skeleton } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
 
 import { EditableInputField } from 'src/components/Base'
-
 import {
   KeyResultCheckMark as KeyResultCheckMarkType,
   KeyResultCheckMarkState,
-} from '../../../../../components/KeyResult/types'
+} from 'src/components/KeyResult/types'
 
 import queries from './queries.gql'
 
-export const KeyResultCheckMark = ({ id, description, state }: Partial<KeyResultCheckMarkType>) => {
-  const [isChecked, setIsChecked] = useState(state === KeyResultCheckMarkState.CHECKED)
+interface KeyResultCheckMarkProperties {
+  node: Partial<KeyResultCheckMarkType>
+  refresh: () => void
+}
+
+export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperties) => {
+  const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
   const [toggleCheckMark, { loading }] = useMutation(queries.TOGGLE_CHECK_MARK, {
     variables: {
-      id,
+      id: node?.id,
     },
     onCompleted: (data) => {
       setIsChecked(data.toggleCheckMark.state === KeyResultCheckMarkState.CHECKED)
     },
   })
 
+  const isLoaded = Boolean(node)
   const handleChange = async () => {
-    void toggleCheckMark()
+    await toggleCheckMark()
+    refresh()
   }
 
   useEffect(() => {
-    setIsChecked(state === KeyResultCheckMarkState.CHECKED)
-  }, [state, setIsChecked])
+    setIsChecked(node?.state === KeyResultCheckMarkState.CHECKED)
+  }, [node?.state, setIsChecked])
 
   return (
-    <Skeleton isLoaded={Boolean(id)} w="full">
+    <Skeleton isLoaded={isLoaded} w="full">
       <Stack direction="row" alignItems="center">
         <Checkbox isChecked={isChecked} isDisabled={loading} onChange={handleChange} />
-        <EditableInputField isWaiting={loading} value={description} isLoaded={Boolean(id)} />
+        <EditableInputField isWaiting={loading} value={node?.description} isLoaded={isLoaded} />
       </Stack>
     </Skeleton>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,0 +1,8 @@
+import { Checkbox } from '@chakra-ui/react'
+import React from 'react'
+
+import { KeyResultCheckMark as KeyResultCheckMarkType } from '../../../../../components/KeyResult/types'
+
+export const KeyResultCheckMark = ({ id, description }: KeyResultCheckMarkType) => (
+  <Checkbox>{description}</Checkbox>
+)

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -113,7 +113,6 @@ export const KeyResultCheckMark = ({
           onChange={handleChange}
         />
         <EditableInputField
-          showControls
           autoFocus={isDraft}
           isWaiting={isWaiting}
           value={node?.description}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -17,7 +17,7 @@ import queries from './queries.gql'
 interface KeyResultCheckMarkProperties {
   draftCheckMarks?: string[]
   node?: Partial<KeyResultCheckMarkType>
-  refresh?: () => void
+  onUpdate?: () => void
   index?: number
   checklistLength?: number
   onCreate?: () => void
@@ -25,7 +25,7 @@ interface KeyResultCheckMarkProperties {
 
 export const KeyResultCheckMark = ({
   node,
-  refresh,
+  onUpdate,
   draftCheckMarks,
   index,
   checklistLength,
@@ -43,14 +43,14 @@ export const KeyResultCheckMark = ({
     },
     onCompleted: (data) => {
       setIsChecked(data.toggleCheckMark.state === KeyResultCheckMarkState.CHECKED)
-      if (refresh) refresh()
+      if (onUpdate) onUpdate()
     },
   })
   const [updateCheckMarkDescription, { loading: isUpdatingDescription }] = useMutation(
     queries.UPDATE_CHECK_MARK_DESCRIPTION,
     {
       onCompleted: () => {
-        if (refresh) refresh()
+        if (onUpdate) onUpdate()
       },
     },
   )
@@ -127,7 +127,7 @@ export const KeyResultCheckMark = ({
         <DeleteCheckMarkButton
           buttonRef={removeCheckmarkButton}
           checkMarkID={node?.id}
-          refresh={refresh}
+          refresh={onUpdate}
           isVisible={isHovering && !isEditing}
           canDelete={canDelete}
         />

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,13 +1,8 @@
 import { useMutation } from '@apollo/client'
-import {
-  Checkbox,
-  Stack,
-  Editable,
-  EditablePreview,
-  EditableInput,
-  Skeleton,
-} from '@chakra-ui/react'
+import { Checkbox, Stack, Skeleton } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
+
+import { EditableInputField } from 'src/components/Base'
 
 import {
   KeyResultCheckMark as KeyResultCheckMarkType,
@@ -18,7 +13,7 @@ import queries from './queries.gql'
 
 export const KeyResultCheckMark = ({ id, description, state }: Partial<KeyResultCheckMarkType>) => {
   const [isChecked, setIsChecked] = useState(state === KeyResultCheckMarkState.CHECKED)
-  const [toggleCheckMark] = useMutation(queries.TOGGLE_CHECK_MARK, {
+  const [toggleCheckMark, { loading }] = useMutation(queries.TOGGLE_CHECK_MARK, {
     variables: {
       id,
     },
@@ -38,11 +33,8 @@ export const KeyResultCheckMark = ({ id, description, state }: Partial<KeyResult
   return (
     <Skeleton isLoaded={Boolean(id)} w="full">
       <Stack direction="row" alignItems="center">
-        <Checkbox isChecked={isChecked} onChange={handleChange} />
-        <Editable value={description} w="full">
-          <EditablePreview />
-          <EditableInput />
-        </Editable>
+        <Checkbox isChecked={isChecked} isDisabled={loading} onChange={handleChange} />
+        <EditableInputField isWaiting={loading} value={description} isLoaded={Boolean(id)} />
       </Stack>
     </Skeleton>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -18,12 +18,18 @@ interface KeyResultCheckMarkProperties {
   draftCheckMarks?: string[]
   node?: Partial<KeyResultCheckMarkType>
   refresh?: () => void
+  index?: number
+  checklistLength?: number
+  onCreate?: () => void
 }
 
 export const KeyResultCheckMark = ({
   node,
   refresh,
   draftCheckMarks,
+  index,
+  checklistLength,
+  onCreate,
 }: KeyResultCheckMarkProperties) => {
   const [isHovering, setIsHovering] = useState(false)
   const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
@@ -76,6 +82,10 @@ export const KeyResultCheckMark = ({
     if (isHovering) setIsHovering(false)
   }
 
+  const handleEnterKey = () => {
+    if (index && checklistLength && index === checklistLength - 1 && onCreate) onCreate()
+  }
+
   useEffect(() => {
     setIsChecked(node?.state === KeyResultCheckMarkState.CHECKED)
   }, [node?.state, setIsChecked])
@@ -96,6 +106,7 @@ export const KeyResultCheckMark = ({
           startWithEditView={isDraft}
           isDisabled={!canUpdate}
           onSubmit={handleNewCheckMarkDescription}
+          onPressedEnter={handleEnterKey}
         />
         <DeleteCheckMarkButton
           checkMarkID={node?.id}

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -11,8 +11,8 @@ import {
 import queries from './queries.gql'
 
 interface KeyResultCheckMarkProperties {
-  node: Partial<KeyResultCheckMarkType>
-  refresh: () => void
+  node?: Partial<KeyResultCheckMarkType>
+  refresh?: () => void
 }
 
 export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperties) => {
@@ -29,7 +29,7 @@ export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperti
   const isLoaded = Boolean(node)
   const handleChange = async () => {
     await toggleCheckMark()
-    refresh()
+    if (refresh) refresh()
   }
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperti
   }, [node?.state, setIsChecked])
 
   return (
-    <Skeleton isLoaded={isLoaded} w="full">
+    <Skeleton isLoaded={isLoaded} w="full" fadeDuration={0}>
       <Stack direction="row" alignItems="center">
         <Checkbox isChecked={isChecked} isDisabled={loading} onChange={handleChange} />
         <EditableInputField isWaiting={loading} value={node?.description} isLoaded={isLoaded} />

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,10 +1,23 @@
-import { Checkbox, Skeleton } from '@chakra-ui/react'
+import {
+  Checkbox,
+  Stack,
+  Editable,
+  EditablePreview,
+  EditableInput,
+  Skeleton,
+} from '@chakra-ui/react'
 import React from 'react'
 
 import { KeyResultCheckMark as KeyResultCheckMarkType } from '../../../../../components/KeyResult/types'
 
 export const KeyResultCheckMark = ({ id, description }: Partial<KeyResultCheckMarkType>) => (
-  <Skeleton isLoaded={Boolean(id)}>
-    <Checkbox>{description}</Checkbox>
+  <Skeleton isLoaded={Boolean(id)} w="full">
+    <Stack direction="row" alignItems="center">
+      <Checkbox />
+      <Editable value={description} w="full">
+        <EditablePreview />
+        <EditableInput />
+      </Editable>
+    </Stack>
   </Skeleton>
 )

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client'
-import { Checkbox, Stack, Skeleton } from '@chakra-ui/react'
+import { HStack, Checkbox, Skeleton } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
 
 import { EditableInputField } from 'src/components/Base'
@@ -9,6 +9,7 @@ import {
 } from 'src/components/KeyResult/types'
 import { GraphQLEffect } from 'src/components/types'
 
+import { DeleteCheckMarkButton } from './ActionButtons/delete-checkmark'
 import queries from './queries.gql'
 
 interface KeyResultCheckMarkProperties {
@@ -22,6 +23,7 @@ export const KeyResultCheckMark = ({
   refresh,
   draftCheckMarks,
 }: KeyResultCheckMarkProperties) => {
+  const [isHovering, setIsHovering] = useState(false)
   const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
   const [toggleCheckMark, { loading }] = useMutation(queries.TOGGLE_CHECK_MARK, {
     variables: {
@@ -35,9 +37,18 @@ export const KeyResultCheckMark = ({
   const isLoaded = Boolean(node)
   const isDraft = typeof node?.id === 'undefined' ? false : draftCheckMarks?.includes(node.id)
   const canUpdate = node?.policy?.update === GraphQLEffect.ALLOW
+
   const handleChange = async () => {
     await toggleCheckMark()
     if (refresh) refresh()
+  }
+
+  const handleMouseEnter = () => {
+    if (!isHovering) setIsHovering(true)
+  }
+
+  const handleMouseLeave = () => {
+    if (isHovering) setIsHovering(false)
   }
 
   useEffect(() => {
@@ -46,7 +57,7 @@ export const KeyResultCheckMark = ({
 
   return (
     <Skeleton isLoaded={isLoaded} w="full" fadeDuration={0}>
-      <Stack direction="row" alignItems="center">
+      <HStack alignItems="center" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <Checkbox
           isChecked={isChecked}
           isDisabled={loading || !canUpdate}
@@ -59,7 +70,8 @@ export const KeyResultCheckMark = ({
           isLoaded={isLoaded}
           startWithEditView={isDraft}
         />
-      </Stack>
+        <DeleteCheckMarkButton keyResultID={node?.id} refresh={refresh} isVisible={isHovering} />
+      </HStack>
     </Skeleton>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -93,8 +93,16 @@ export const KeyResultCheckMark = ({
     if (isHovering) setIsHovering(false)
   }
 
-  const handleEnterKey = () => {
-    if (index && checklistLength && index === checklistLength - 1 && onCreate) onCreate()
+  const handleEnterKey = (value?: string) => {
+    const isEmpty = !value || value.trim() === ''
+    if (
+      typeof index !== 'undefined' &&
+      checklistLength &&
+      index === checklistLength - 1 &&
+      !isEmpty &&
+      onCreate
+    )
+      onCreate()
   }
 
   const handleStartEdit = () => {

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -11,11 +11,16 @@ import {
 import queries from './queries.gql'
 
 interface KeyResultCheckMarkProperties {
+  draftCheckMarks?: string[]
   node?: Partial<KeyResultCheckMarkType>
   refresh?: () => void
 }
 
-export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperties) => {
+export const KeyResultCheckMark = ({
+  node,
+  refresh,
+  draftCheckMarks,
+}: KeyResultCheckMarkProperties) => {
   const [isChecked, setIsChecked] = useState(node?.state === KeyResultCheckMarkState.CHECKED)
   const [toggleCheckMark, { loading }] = useMutation(queries.TOGGLE_CHECK_MARK, {
     variables: {
@@ -27,6 +32,7 @@ export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperti
   })
 
   const isLoaded = Boolean(node)
+  const isDraft = typeof node?.id === 'undefined' ? false : draftCheckMarks?.includes(node.id)
   const handleChange = async () => {
     await toggleCheckMark()
     if (refresh) refresh()
@@ -40,7 +46,12 @@ export const KeyResultCheckMark = ({ node, refresh }: KeyResultCheckMarkProperti
     <Skeleton isLoaded={isLoaded} w="full" fadeDuration={0}>
       <Stack direction="row" alignItems="center">
         <Checkbox isChecked={isChecked} isDisabled={loading} onChange={handleChange} />
-        <EditableInputField isWaiting={loading} value={node?.description} isLoaded={isLoaded} />
+        <EditableInputField
+          isWaiting={loading}
+          value={node?.description}
+          isLoaded={isLoaded}
+          startWithEditView={isDraft}
+        />
       </Stack>
     </Skeleton>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/check-mark.tsx
@@ -70,7 +70,7 @@ export const KeyResultCheckMark = ({
           isLoaded={isLoaded}
           startWithEditView={isDraft}
         />
-        <DeleteCheckMarkButton keyResultID={node?.id} refresh={refresh} isVisible={isHovering} />
+        <DeleteCheckMarkButton checkMarkID={node?.id} refresh={refresh} isVisible={isHovering} />
       </HStack>
     </Skeleton>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -41,7 +41,7 @@ export const KeyResultChecklist = ({
           onCreate={handleCreateCheckmark}
         />
       ))}
-      {canCreate && nodes.length > 0 && (
+      {canCreate && nodes.length > 0 && nodes.length < 16 && (
         <CreateCheckMarkButton
           keyResultID={keyResultID}
           createButtonReference={createButtonReference}

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -23,7 +23,7 @@ export const KeyResultChecklist = ({
 }: KeyResultChecklistProperties) => {
   const draftCheckMarks = useRecoilValue(draftCheckMarksAtom(keyResultID))
 
-  return (
+  return nodes.length > 0 ? (
     <Stack alignItems="flex-start">
       {nodes.map((node) => (
         <KeyResultCheckMark
@@ -37,5 +37,6 @@ export const KeyResultChecklist = ({
         <NewCheckMark refresh={refresh} keyResultID={keyResultID} />
       )}
     </Stack>
-  )
+  ) : // eslint-disable-next-line unicorn/no-null
+  null
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,19 +1,44 @@
 import { Stack } from '@chakra-ui/layout'
+import { Button } from '@chakra-ui/react'
 import React from 'react'
+import { useIntl } from 'react-intl'
 
+import { PlusOutline } from 'src/components/Icon'
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
 
 import { KeyResultCheckMark } from './check-mark'
+import messages from './messages'
 
 interface KeyResultChecklistProperties {
   nodes: KeyResultCheckMarkType[]
   refresh: () => void
 }
 
-export const KeyResultChecklist = ({ nodes, refresh }: KeyResultChecklistProperties) => (
-  <Stack>
-    {nodes.map((node) => (
-      <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
-    ))}
-  </Stack>
-)
+export const KeyResultChecklist = ({ nodes, refresh }: KeyResultChecklistProperties) => {
+  const intl = useIntl()
+
+  return (
+    <Stack alignItems="flex-start">
+      {nodes.map((node) => (
+        <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
+      ))}
+      {nodes.length > 0 && (
+        <Button
+          variant="text"
+          pl={0}
+          colorScheme="brand"
+          leftIcon={
+            <PlusOutline
+              desc={intl.formatMessage(messages.newCheckMarkButtonIconDescription)}
+              stroke="currentColor"
+              fill="currentColor"
+              fontSize="xl"
+            />
+          }
+        >
+          {intl.formatMessage(messages.newCheckMarkButtonLabel)}
+        </Button>
+      )}
+    </Stack>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@apollo/client'
 import { Stack } from '@chakra-ui/layout'
 import { Button } from '@chakra-ui/react'
 import React from 'react'
@@ -8,14 +9,31 @@ import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/Key
 
 import { KeyResultCheckMark } from './check-mark'
 import messages from './messages'
+import queries from './queries.gql'
 
 interface KeyResultChecklistProperties {
+  keyResultID?: string
   nodes: KeyResultCheckMarkType[]
   refresh: () => void
 }
 
-export const KeyResultChecklist = ({ nodes, refresh }: KeyResultChecklistProperties) => {
+export const KeyResultChecklist = ({
+  nodes,
+  refresh,
+  keyResultID,
+}: KeyResultChecklistProperties) => {
   const intl = useIntl()
+  const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
+    variables: {
+      keyResultID,
+      description: intl.formatMessage(messages.draftCheckMarkDescription),
+    },
+  })
+
+  const handleNewCheckMark = async () => {
+    await createCheckMark()
+    refresh()
+  }
 
   return (
     <Stack alignItems="flex-start">
@@ -27,6 +45,7 @@ export const KeyResultChecklist = ({ nodes, refresh }: KeyResultChecklistPropert
           variant="text"
           pl={0}
           colorScheme="brand"
+          isDisabled={loading}
           leftIcon={
             <PlusOutline
               desc={intl.formatMessage(messages.newCheckMarkButtonIconDescription)}
@@ -35,6 +54,7 @@ export const KeyResultChecklist = ({ nodes, refresh }: KeyResultChecklistPropert
               fontSize="xl"
             />
           }
+          onClick={handleNewCheckMark}
         >
           {intl.formatMessage(messages.newCheckMarkButtonLabel)}
         </Button>

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,16 +1,18 @@
 import { Stack } from '@chakra-ui/layout'
 import React from 'react'
 
-import { KeyResultCheckMark } from 'src/components/KeyResult/types'
+import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
+
+import { KeyResultCheckMark } from './check-mark'
 
 interface KeyResultChecklistProperties {
-  nodes: KeyResultCheckMark[]
+  nodes: KeyResultCheckMarkType[]
 }
 
 export const KeyResultChecklist = ({ nodes }: KeyResultChecklistProperties) => (
   <Stack>
-    {nodes.map(({ id }) => (
-      <p key={id}>{id}</p>
+    {nodes.map((checkMark) => (
+      <KeyResultCheckMark key={checkMark.id} {...checkMark} />
     ))}
   </Stack>
 )

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,10 +1,12 @@
 import { Stack } from '@chakra-ui/layout'
 import React from 'react'
+import { useRecoilValue } from 'recoil'
 
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
+import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 
 import { KeyResultCheckMark } from './check-mark'
-import { NewCheckMark } from './new-checkmark-button'
+import { NewCheckMark } from './new-checkmark'
 
 interface KeyResultChecklistProperties {
   keyResultID?: string
@@ -16,11 +18,20 @@ export const KeyResultChecklist = ({
   nodes,
   refresh,
   keyResultID,
-}: KeyResultChecklistProperties) => (
-  <Stack alignItems="flex-start">
-    {nodes.map((node) => (
-      <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
-    ))}
-    {nodes.length > 0 && <NewCheckMark refresh={refresh} keyResultID={keyResultID} />}
-  </Stack>
-)
+}: KeyResultChecklistProperties) => {
+  const draftCheckMarks = useRecoilValue(draftCheckMarksAtom(keyResultID))
+
+  return (
+    <Stack alignItems="flex-start">
+      {nodes.map((node) => (
+        <KeyResultCheckMark
+          key={node.id}
+          node={node}
+          refresh={refresh}
+          draftCheckMarks={draftCheckMarks}
+        />
+      ))}
+      {nodes.length > 0 && <NewCheckMark refresh={refresh} keyResultID={keyResultID} />}
+    </Stack>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -5,8 +5,8 @@ import { useRecoilValue } from 'recoil'
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
 import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 
+import { CreateCheckMark } from './ActionButtons/create-checkmark'
 import { KeyResultCheckMark } from './check-mark'
-import { NewCheckMark } from './new-checkmark'
 
 interface KeyResultChecklistProperties {
   keyResultID?: string
@@ -34,7 +34,7 @@ export const KeyResultChecklist = ({
         />
       ))}
       {canCreate && nodes.length > 0 && (
-        <NewCheckMark refresh={refresh} keyResultID={keyResultID} />
+        <CreateCheckMark refresh={refresh} keyResultID={keyResultID} />
       )}
     </Stack>
   ) : // eslint-disable-next-line unicorn/no-null

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -11,13 +11,13 @@ import { KeyResultCheckMark } from './check-mark'
 interface KeyResultChecklistProperties {
   keyResultID?: string
   nodes: KeyResultCheckMarkType[]
-  refresh: () => void
+  onCreateCheckmark: () => void
   canCreate: boolean
 }
 
 export const KeyResultChecklist = ({
   nodes,
-  refresh,
+  onCreateCheckmark,
   keyResultID,
   canCreate,
 }: KeyResultChecklistProperties) => {
@@ -34,18 +34,18 @@ export const KeyResultChecklist = ({
         <KeyResultCheckMark
           key={node.id}
           node={node}
-          refresh={refresh}
           draftCheckMarks={draftCheckMarks}
           index={index}
           checklistLength={nodes.length}
+          onUpdate={onCreateCheckmark}
           onCreate={handleCreateCheckmark}
         />
       ))}
       {canCreate && nodes.length > 0 && (
         <CreateCheckMarkButton
-          refresh={refresh}
           keyResultID={keyResultID}
           createButtonReference={createButtonReference}
+          onCreate={onCreateCheckmark}
         />
       )}
     </Stack>

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil'
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
 import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 
-import { CreateCheckMark } from './ActionButtons/create-checkmark'
+import { CreateCheckMarkButton } from './ActionButtons/create-checkmark'
 import { KeyResultCheckMark } from './check-mark'
 
 interface KeyResultChecklistProperties {
@@ -34,7 +34,7 @@ export const KeyResultChecklist = ({
         />
       ))}
       {canCreate && nodes.length > 0 && (
-        <CreateCheckMark refresh={refresh} keyResultID={keyResultID} />
+        <CreateCheckMarkButton refresh={refresh} keyResultID={keyResultID} />
       )}
     </Stack>
   ) : // eslint-disable-next-line unicorn/no-null

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@chakra-ui/layout'
+import React from 'react'
+
+import { KeyResultCheckMark } from 'src/components/KeyResult/types'
+
+interface KeyResultChecklistProperties {
+  nodes: KeyResultCheckMark[]
+}
+
+export const KeyResultChecklist = ({ nodes }: KeyResultChecklistProperties) => (
+  <Stack>
+    {nodes.map(({ id }) => (
+      <p key={id}>{id}</p>
+    ))}
+  </Stack>
+)

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,6 +1,5 @@
 import { Stack } from '@chakra-ui/layout'
 import React from 'react'
-import { useIntl } from 'react-intl'
 
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
 
@@ -17,15 +16,11 @@ export const KeyResultChecklist = ({
   nodes,
   refresh,
   keyResultID,
-}: KeyResultChecklistProperties) => {
-  const intl = useIntl()
-
-  return (
-    <Stack alignItems="flex-start">
-      {nodes.map((node) => (
-        <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
-      ))}
-      {nodes.length > 0 && <NewCheckMark refresh={refresh} keyResultID={keyResultID} />}
-    </Stack>
-  )
-}
+}: KeyResultChecklistProperties) => (
+  <Stack alignItems="flex-start">
+    {nodes.map((node) => (
+      <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
+    ))}
+    {nodes.length > 0 && <NewCheckMark refresh={refresh} keyResultID={keyResultID} />}
+  </Stack>
+)

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -7,12 +7,13 @@ import { KeyResultCheckMark } from './check-mark'
 
 interface KeyResultChecklistProperties {
   nodes: KeyResultCheckMarkType[]
+  refresh: () => void
 }
 
-export const KeyResultChecklist = ({ nodes }: KeyResultChecklistProperties) => (
+export const KeyResultChecklist = ({ nodes, refresh }: KeyResultChecklistProperties) => (
   <Stack>
-    {nodes.map((checkMark) => (
-      <KeyResultCheckMark key={checkMark.id} {...checkMark} />
+    {nodes.map((node) => (
+      <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
     ))}
   </Stack>
 )

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -29,7 +29,7 @@ export const KeyResultChecklist = ({
   }
 
   return nodes.length > 0 ? (
-    <Stack alignItems="flex-start">
+    <Stack alignItems="flex-start" pt={4}>
       {nodes.map((node, index) => (
         <KeyResultCheckMark
           key={node.id}

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,15 +1,11 @@
-import { useMutation } from '@apollo/client'
 import { Stack } from '@chakra-ui/layout'
-import { Button } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
-import { PlusOutline } from 'src/components/Icon'
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
 
 import { KeyResultCheckMark } from './check-mark'
-import messages from './messages'
-import queries from './queries.gql'
+import { NewCheckMark } from './new-checkmark-button'
 
 interface KeyResultChecklistProperties {
   keyResultID?: string
@@ -23,42 +19,13 @@ export const KeyResultChecklist = ({
   keyResultID,
 }: KeyResultChecklistProperties) => {
   const intl = useIntl()
-  const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
-    variables: {
-      keyResultID,
-      description: intl.formatMessage(messages.draftCheckMarkDescription),
-    },
-  })
-
-  const handleNewCheckMark = async () => {
-    await createCheckMark()
-    refresh()
-  }
 
   return (
     <Stack alignItems="flex-start">
       {nodes.map((node) => (
         <KeyResultCheckMark key={node.id} node={node} refresh={refresh} />
       ))}
-      {nodes.length > 0 && (
-        <Button
-          variant="text"
-          pl={0}
-          colorScheme="brand"
-          isDisabled={loading}
-          leftIcon={
-            <PlusOutline
-              desc={intl.formatMessage(messages.newCheckMarkButtonIconDescription)}
-              stroke="currentColor"
-              fill="currentColor"
-              fontSize="xl"
-            />
-          }
-          onClick={handleNewCheckMark}
-        >
-          {intl.formatMessage(messages.newCheckMarkButtonLabel)}
-        </Button>
-      )}
+      {nodes.length > 0 && <NewCheckMark refresh={refresh} keyResultID={keyResultID} />}
     </Stack>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@chakra-ui/layout'
-import React from 'react'
+import React, { useRef } from 'react'
 import { useRecoilValue } from 'recoil'
 
 import { KeyResultCheckMark as KeyResultCheckMarkType } from 'src/components/KeyResult/types'
@@ -22,19 +22,31 @@ export const KeyResultChecklist = ({
   canCreate,
 }: KeyResultChecklistProperties) => {
   const draftCheckMarks = useRecoilValue(draftCheckMarksAtom(keyResultID))
+  const createButtonReference = useRef<HTMLButtonElement>(null)
+
+  const handleCreateCheckmark = () => {
+    createButtonReference.current?.click()
+  }
 
   return nodes.length > 0 ? (
     <Stack alignItems="flex-start">
-      {nodes.map((node) => (
+      {nodes.map((node, index) => (
         <KeyResultCheckMark
           key={node.id}
           node={node}
           refresh={refresh}
           draftCheckMarks={draftCheckMarks}
+          index={index}
+          checklistLength={nodes.length}
+          onCreate={handleCreateCheckmark}
         />
       ))}
       {canCreate && nodes.length > 0 && (
-        <CreateCheckMarkButton refresh={refresh} keyResultID={keyResultID} />
+        <CreateCheckMarkButton
+          refresh={refresh}
+          keyResultID={keyResultID}
+          createButtonReference={createButtonReference}
+        />
       )}
     </Stack>
   ) : // eslint-disable-next-line unicorn/no-null

--- a/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/checklist.tsx
@@ -12,12 +12,14 @@ interface KeyResultChecklistProperties {
   keyResultID?: string
   nodes: KeyResultCheckMarkType[]
   refresh: () => void
+  canCreate: boolean
 }
 
 export const KeyResultChecklist = ({
   nodes,
   refresh,
   keyResultID,
+  canCreate,
 }: KeyResultChecklistProperties) => {
   const draftCheckMarks = useRecoilValue(draftCheckMarksAtom(keyResultID))
 
@@ -31,7 +33,9 @@ export const KeyResultChecklist = ({
           draftCheckMarks={draftCheckMarks}
         />
       ))}
-      {nodes.length > 0 && <NewCheckMark refresh={refresh} keyResultID={keyResultID} />}
+      {canCreate && nodes.length > 0 && (
+        <NewCheckMark refresh={refresh} keyResultID={keyResultID} />
+      )}
     </Stack>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl'
+
+type KeyResultsSectionChecklistMessage = 'heading'
+
+export default defineMessages<KeyResultsSectionChecklistMessage>({
+  heading: {
+    defaultMessage: 'Check-list',
+    id: 'PktsGq',
+    description: 'This is the title of our checklist section inside the key-result sidebar',
+  },
+})

--- a/src/components/KeyResult/Single/Sections/Checklist/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/messages.ts
@@ -1,35 +1,11 @@
 import { defineMessages } from 'react-intl'
 
-type KeyResultsSectionChecklistMessage =
-  | 'heading'
-  | 'newCheckMarkButtonLabel'
-  | 'newCheckMarkButtonIconDescription'
-  | 'draftCheckMarkDescription'
+type KeyResultsSectionChecklistMessage = 'heading'
 
 export default defineMessages<KeyResultsSectionChecklistMessage>({
   heading: {
     defaultMessage: 'Check-list',
     id: 'PktsGq',
     description: 'This is the title of our checklist section inside the key-result sidebar',
-  },
-
-  newCheckMarkButtonLabel: {
-    defaultMessage: 'Adicionar novo item',
-    id: 'zennqC',
-    description: 'This label appears in our key-result sidebar drawer, in the end of our checklist',
-  },
-
-  newCheckMarkButtonIconDescription: {
-    defaultMessage:
-      'Um ícone do sinal de positivo que, ao clicar, irá adicionar um novo item na checklist',
-    id: 'e2FL3I',
-    description:
-      'This is used by screen readers to understand the insert new check mark icon in our key-result drawer',
-  },
-
-  draftCheckMarkDescription: {
-    defaultMessage: 'Novo item',
-    id: 'qYpqgw',
-    description: 'This is the description used as default by a check mark when we add a new item',
   },
 })

--- a/src/components/KeyResult/Single/Sections/Checklist/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/messages.ts
@@ -4,6 +4,7 @@ type KeyResultsSectionChecklistMessage =
   | 'heading'
   | 'newCheckMarkButtonLabel'
   | 'newCheckMarkButtonIconDescription'
+  | 'draftCheckMarkDescription'
 
 export default defineMessages<KeyResultsSectionChecklistMessage>({
   heading: {
@@ -24,5 +25,11 @@ export default defineMessages<KeyResultsSectionChecklistMessage>({
     id: 'e2FL3I',
     description:
       'This is used by screen readers to understand the insert new check mark icon in our key-result drawer',
+  },
+
+  draftCheckMarkDescription: {
+    defaultMessage: 'Novo item',
+    id: 'qYpqgw',
+    description: 'This is the description used as default by a check mark when we add a new item',
   },
 })

--- a/src/components/KeyResult/Single/Sections/Checklist/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/messages.ts
@@ -1,11 +1,18 @@
 import { defineMessages } from 'react-intl'
 
-type KeyResultsSectionChecklistMessage = 'heading'
+type KeyResultsSectionChecklistMessage = 'heading' | 'collapseButtonDesc'
 
 export default defineMessages<KeyResultsSectionChecklistMessage>({
   heading: {
     defaultMessage: 'Check-list',
     id: 'PktsGq',
     description: 'This is the title of our checklist section inside the key-result sidebar',
+  },
+
+  collapseButtonDesc: {
+    defaultMessage: 'Uma seta que ao ser clicada expande a checklist deste resultado-chave',
+    id: 'SsQRcF',
+    description:
+      'This message is used by screen readers to explain the collapse icon in our key-result sidebar on the checklist section',
   },
 })

--- a/src/components/KeyResult/Single/Sections/Checklist/messages.ts
+++ b/src/components/KeyResult/Single/Sections/Checklist/messages.ts
@@ -1,11 +1,28 @@
 import { defineMessages } from 'react-intl'
 
-type KeyResultsSectionChecklistMessage = 'heading'
+type KeyResultsSectionChecklistMessage =
+  | 'heading'
+  | 'newCheckMarkButtonLabel'
+  | 'newCheckMarkButtonIconDescription'
 
 export default defineMessages<KeyResultsSectionChecklistMessage>({
   heading: {
     defaultMessage: 'Check-list',
     id: 'PktsGq',
     description: 'This is the title of our checklist section inside the key-result sidebar',
+  },
+
+  newCheckMarkButtonLabel: {
+    defaultMessage: 'Adicionar novo item',
+    id: 'zennqC',
+    description: 'This label appears in our key-result sidebar drawer, in the end of our checklist',
+  },
+
+  newCheckMarkButtonIconDescription: {
+    defaultMessage:
+      'Um ícone do sinal de positivo que, ao clicar, irá adicionar um novo item na checklist',
+    id: 'e2FL3I',
+    description:
+      'This is used by screen readers to understand the insert new check mark icon in our key-result drawer',
   },
 })

--- a/src/components/KeyResult/Single/Sections/Checklist/new-checkmark-button.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/new-checkmark-button.tsx
@@ -1,0 +1,49 @@
+import { useMutation } from '@apollo/client'
+import { Button } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import { PlusOutline } from 'src/components/Icon'
+
+import messages from './messages'
+import queries from './queries.gql'
+
+interface NewCheckMarkProperties {
+  keyResultID?: string
+  refresh: () => void
+}
+
+export const NewCheckMark = ({ refresh, keyResultID }: NewCheckMarkProperties) => {
+  const intl = useIntl()
+  const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
+    variables: {
+      keyResultID,
+      description: intl.formatMessage(messages.draftCheckMarkDescription),
+    },
+  })
+
+  const handleNewCheckMark = async () => {
+    await createCheckMark()
+    refresh()
+  }
+
+  return (
+    <Button
+      variant="text"
+      pl={0}
+      colorScheme="brand"
+      isDisabled={loading}
+      leftIcon={
+        <PlusOutline
+          desc={intl.formatMessage(messages.newCheckMarkButtonIconDescription)}
+          stroke="currentColor"
+          fill="currentColor"
+          fontSize="xl"
+        />
+      }
+      onClick={handleNewCheckMark}
+    >
+      {intl.formatMessage(messages.newCheckMarkButtonLabel)}
+    </Button>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/new-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/new-checkmark.tsx
@@ -12,10 +12,11 @@ import queries from './queries.gql'
 
 interface NewCheckMarkProperties {
   keyResultID?: string
+  label?: string
   refresh: () => void
 }
 
-export const NewCheckMark = ({ refresh, keyResultID }: NewCheckMarkProperties) => {
+export const NewCheckMark = ({ label, refresh, keyResultID }: NewCheckMarkProperties) => {
   const intl = useIntl()
   const [draftCheckMarks, setDraftCheckMarks] = useRecoilState(draftCheckMarksAtom(keyResultID))
   const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
@@ -50,7 +51,7 @@ export const NewCheckMark = ({ refresh, keyResultID }: NewCheckMarkProperties) =
       }
       onClick={handleNewCheckMark}
     >
-      {intl.formatMessage(messages.newCheckMarkButtonLabel)}
+      {label ?? intl.formatMessage(messages.newCheckMarkButtonLabel)}
     </Button>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/new-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/new-checkmark.tsx
@@ -2,8 +2,10 @@ import { useMutation } from '@apollo/client'
 import { Button } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
+import { useRecoilState } from 'recoil'
 
 import { PlusOutline } from 'src/components/Icon'
+import { draftCheckMarksAtom } from 'src/state/recoil/key-result/checklist'
 
 import messages from './messages'
 import queries from './queries.gql'
@@ -15,10 +17,15 @@ interface NewCheckMarkProperties {
 
 export const NewCheckMark = ({ refresh, keyResultID }: NewCheckMarkProperties) => {
   const intl = useIntl()
+  const [draftCheckMarks, setDraftCheckMarks] = useRecoilState(draftCheckMarksAtom(keyResultID))
   const [createCheckMark, { loading }] = useMutation(queries.CREATE_CHECK_MARK, {
     variables: {
       keyResultID,
       description: intl.formatMessage(messages.draftCheckMarkDescription),
+    },
+    onCompleted: (data) => {
+      const newDraftCheckMarks = [...draftCheckMarks, data.createKeyResultCheckMark.id]
+      setDraftCheckMarks(newDraftCheckMarks)
     },
   })
 

--- a/src/components/KeyResult/Single/Sections/Checklist/new-checkmark.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/new-checkmark.tsx
@@ -38,7 +38,8 @@ export const NewCheckMark = ({ label, refresh, keyResultID }: NewCheckMarkProper
   return (
     <Button
       variant="text"
-      pl={0}
+      p={0}
+      h="auto"
       colorScheme="brand"
       isDisabled={loading}
       leftIcon={

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -15,6 +15,9 @@ query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
           id
           description
           state
+          policy {
+            update
+          }
         }
       }
     }
@@ -33,5 +36,8 @@ mutation CREATE_CHECK_MARK($keyResultID: ID!, $description: String!) {
     id
     description
     state
+    policy {
+      update
+    }
   }
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -30,14 +30,3 @@ mutation TOGGLE_CHECK_MARK($id: ID!) {
     state
   }
 }
-
-mutation CREATE_CHECK_MARK($keyResultID: ID!, $description: String!) {
-  createKeyResultCheckMark(data: { keyResultId: $keyResultID, description: $description }) {
-    id
-    description
-    state
-    policy {
-      update
-    }
-  }
-}

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -2,6 +2,9 @@ query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
   keyResult(id: $id) {
     id
     checkList {
+      policy {
+        create
+      }
       progress {
         total
         numberOfChecked

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -17,3 +17,10 @@ query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
     }
   }
 }
+
+mutation TOGGLE_CHECK_MARK($id: String!) {
+  toggleCheckMark(data: { id: $id }) {
+    id
+    state
+  }
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -24,3 +24,11 @@ mutation TOGGLE_CHECK_MARK($id: ID!) {
     state
   }
 }
+
+mutation CREATE_CHECK_MARK($keyResultID: ID!, $description: String!) {
+  createKeyResultCheckMark(data: { keyResultId: $keyResultID, description: $description }) {
+    id
+    description
+    state
+  }
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -1,0 +1,19 @@
+query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
+  keyResult(id: $id) {
+    id
+    checkList {
+      progress {
+        total
+        numberOfChecked
+        progress
+      }
+      edges {
+        node {
+          id
+          description
+          state
+        }
+      }
+    }
+  }
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -18,7 +18,7 @@ query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
   }
 }
 
-mutation TOGGLE_CHECK_MARK($id: String!) {
+mutation TOGGLE_CHECK_MARK($id: ID!) {
   toggleCheckMark(data: { id: $id }) {
     id
     state

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -17,6 +17,7 @@ query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
           state
           policy {
             update
+            delete
           }
         }
       }

--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -31,3 +31,9 @@ mutation TOGGLE_CHECK_MARK($id: ID!) {
     state
   }
 }
+
+mutation UPDATE_CHECK_MARK_DESCRIPTION($id: ID!, $description: String!) {
+  updateCheckMarkDescription(id: $id, data: { description: $description }) {
+    id
+  }
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/skeleton.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/skeleton.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const KeyResultChecklistSkeleton = () => <p>Ok</p>

--- a/src/components/KeyResult/Single/Sections/Checklist/skeleton.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/skeleton.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { KeyResultCheckMark } from './check-mark'
 
 export const KeyResultChecklistSkeleton = () => (
-  <Stack>
+  <Stack pt={2}>
     <KeyResultCheckMark />
     <KeyResultCheckMark />
     <KeyResultCheckMark />

--- a/src/components/KeyResult/Single/Sections/Checklist/skeleton.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/skeleton.tsx
@@ -1,3 +1,12 @@
+import { Stack } from '@chakra-ui/react'
 import React from 'react'
 
-export const KeyResultChecklistSkeleton = () => <p>Ok</p>
+import { KeyResultCheckMark } from './check-mark'
+
+export const KeyResultChecklistSkeleton = () => (
+  <Stack>
+    <KeyResultCheckMark />
+    <KeyResultCheckMark />
+    <KeyResultCheckMark />
+  </Stack>
+)

--- a/src/components/KeyResult/Single/Sections/Checklist/toggle-collapse.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/toggle-collapse.tsx
@@ -1,0 +1,30 @@
+import { IconButton } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import { ChevronDown } from 'src/components/Icon'
+
+import messages from './messages'
+
+type ToggleCollapseProperties = {
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export const ToggleCollapse = ({ onToggle, isOpen }: ToggleCollapseProperties) => {
+  const intl = useIntl()
+
+  return (
+    <IconButton
+      aria-label={intl.formatMessage(messages.collapseButtonDesc)}
+      icon={
+        <ChevronDown
+          desc={intl.formatMessage(messages.collapseButtonDesc)}
+          transition="all .2s ease-in-out"
+          transform={isOpen ? 'rotate(180deg)' : ''}
+        />
+      }
+      onClick={onToggle}
+    />
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/toggle-collapse.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/toggle-collapse.tsx
@@ -17,6 +17,7 @@ export const ToggleCollapse = ({ onToggle, isOpen }: ToggleCollapseProperties) =
   return (
     <IconButton
       aria-label={intl.formatMessage(messages.collapseButtonDesc)}
+      h="auto"
       icon={
         <ChevronDown
           desc={intl.formatMessage(messages.collapseButtonDesc)}

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -1,0 +1,25 @@
+import { Stack } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import { KeyResultSectionHeading } from '../Heading/wrapper'
+
+import messages from './messages'
+
+interface KeyResultChecklistWrapperProperties {
+  keyResultID?: string
+  isLoading?: boolean
+}
+
+export const KeyResultChecklistWrapper = ({
+  keyResultID,
+  isLoading,
+}: KeyResultChecklistWrapperProperties) => {
+  const intl = useIntl()
+
+  return (
+    <Stack>
+      <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
+    </Stack>
+  )
+}

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -28,6 +28,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
     useConnectionEdges<KeyResultCheckMark>()
   const intl = useIntl()
   const [getChecklist, { called, loading }] = useLazyQuery(queries.GET_CHECKLIST_OF_KEY_RESULT, {
+    fetchPolicy: 'network-only',
     onCompleted: (data) => {
       setKeyResultChecklist(data.keyResult.checkList)
     },

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -1,6 +1,6 @@
 import { useLazyQuery } from '@apollo/client'
 import { Stack } from '@chakra-ui/react'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { useRecoilState } from 'recoil'
 
@@ -34,20 +34,22 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
     },
   })
 
-  const isLoading = (called && loading) || !isChecklistLoaded
+  const isLoading = called && loading && !isChecklistLoaded
+  const refreshChecklist = useCallback(() => {
+    getChecklist({
+      variables: {
+        id: keyResultID,
+      },
+    })
+  }, [getChecklist, keyResultID])
 
   useEffect(() => {
     updateChecklistEdges(keyResultChecklist?.edges)
   }, [keyResultChecklist, updateChecklistEdges])
 
   useEffect(() => {
-    if (keyResultID)
-      getChecklist({
-        variables: {
-          id: keyResultID,
-        },
-      })
-  }, [keyResultID, getChecklist])
+    if (keyResultID) refreshChecklist()
+  }, [keyResultID, refreshChecklist])
 
   return (
     <Stack>
@@ -55,7 +57,11 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
         <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
         <OptionBarWrapper progress={keyResultChecklist?.progress} />
       </Stack>
-      {isLoading ? <KeyResultChecklistSkeleton /> : <KeyResultChecklist nodes={checklist} />}
+      {isLoading ? (
+        <KeyResultChecklistSkeleton />
+      ) : (
+        <KeyResultChecklist nodes={checklist} refresh={refreshChecklist} />
+      )}
     </Stack>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -60,7 +60,11 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
       {isLoading ? (
         <KeyResultChecklistSkeleton />
       ) : (
-        <KeyResultChecklist nodes={checklist} refresh={refreshChecklist} />
+        <KeyResultChecklist
+          nodes={checklist}
+          refresh={refreshChecklist}
+          keyResultID={keyResultID}
+        />
       )}
     </Stack>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -66,7 +66,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
   }, [keyResultID, refreshChecklist])
 
   return (
-    <Stack>
+    <Stack spacing={0}>
       <Stack direction="row" alignItems="center">
         <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
         <OptionBarWrapper

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -1,44 +1,60 @@
+import { useLazyQuery } from '@apollo/client'
 import { Stack } from '@chakra-ui/react'
 import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
-import { useRecoilValue } from 'recoil'
+import { useRecoilState } from 'recoil'
 
+import { KeyResultCheckMark } from 'src/components/KeyResult/types'
 import { useConnectionEdges } from 'src/state/hooks/useConnectionEdges/hook'
-import { keyResultAtomFamily } from 'src/state/recoil/key-result'
+import { keyResultChecklistAtom } from 'src/state/recoil/key-result/checklist'
 
 import { KeyResultSectionHeading } from '../Heading/wrapper'
 
+import { OptionBarWrapper } from './OptionBar/wrapper'
 import { KeyResultChecklist } from './checklist'
 import messages from './messages'
+import queries from './queries.gql'
 import { KeyResultChecklistSkeleton } from './skeleton'
 
 interface KeyResultChecklistWrapperProperties {
   keyResultID?: string
-  isLoading?: boolean
 }
 
-export const KeyResultChecklistWrapper = ({
-  keyResultID,
-  isLoading,
-}: KeyResultChecklistWrapperProperties) => {
-  const keyResult = useRecoilValue(keyResultAtomFamily(keyResultID))
-  const [checklist, updateChecklistEdges, _, isChecklistLoaded] = useConnectionEdges(
-    keyResult?.checkList?.edges,
+export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWrapperProperties) => {
+  const [keyResultChecklist, setKeyResultChecklist] = useRecoilState(
+    keyResultChecklistAtom(keyResultID),
   )
+  const [checklist, updateChecklistEdges, _, isChecklistLoaded] =
+    useConnectionEdges<KeyResultCheckMark>()
   const intl = useIntl()
+  const [getChecklist, { called, loading }] = useLazyQuery(queries.GET_CHECKLIST_OF_KEY_RESULT, {
+    onCompleted: (data) => {
+      setKeyResultChecklist(data.keyResult.checkList)
+    },
+  })
+
+  const isLoading = (called && loading) || !isChecklistLoaded
 
   useEffect(() => {
-    updateChecklistEdges(keyResult?.checkList?.edges)
-  }, [keyResult, updateChecklistEdges])
+    updateChecklistEdges(keyResultChecklist?.edges)
+  }, [keyResultChecklist, updateChecklistEdges])
+
+  useEffect(() => {
+    if (keyResultID)
+      getChecklist({
+        variables: {
+          id: keyResultID,
+        },
+      })
+  }, [keyResultID, getChecklist])
 
   return (
     <Stack>
-      <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
-      {isLoading || !isChecklistLoaded ? (
-        <KeyResultChecklistSkeleton />
-      ) : (
-        <KeyResultChecklist nodes={checklist} />
-      )}
+      <Stack direction="row" alignItems="center">
+        <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
+        <OptionBarWrapper progress={keyResultChecklist?.progress} />
+      </Stack>
+      {isLoading ? <KeyResultChecklistSkeleton /> : <KeyResultChecklist nodes={checklist} />}
     </Stack>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -55,7 +55,11 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
     <Stack>
       <Stack direction="row" alignItems="center">
         <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
-        <OptionBarWrapper progress={keyResultChecklist?.progress} />
+        <OptionBarWrapper
+          progress={keyResultChecklist?.progress}
+          refresh={refreshChecklist}
+          keyResultID={keyResultID}
+        />
       </Stack>
       {isLoading ? (
         <KeyResultChecklistSkeleton />

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl'
 import { useRecoilState } from 'recoil'
 
 import { KeyResultCheckMark } from 'src/components/KeyResult/types'
+import { GraphQLEffect } from 'src/components/types'
 import { useConnectionEdges } from 'src/state/hooks/useConnectionEdges/hook'
 import { keyResultChecklistAtom } from 'src/state/recoil/key-result/checklist'
 
@@ -35,6 +36,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
   })
 
   const isLoading = called && loading && !isChecklistLoaded
+  const canCreate = keyResultChecklist?.policy?.create === GraphQLEffect.ALLOW
   const refreshChecklist = useCallback(() => {
     getChecklist({
       variables: {
@@ -59,6 +61,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
           progress={keyResultChecklist?.progress}
           refresh={refreshChecklist}
           keyResultID={keyResultID}
+          canCreate={canCreate}
         />
       </Stack>
       {isLoading ? (
@@ -68,6 +71,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
           nodes={checklist}
           refresh={refreshChecklist}
           keyResultID={keyResultID}
+          canCreate={canCreate}
         />
       )}
     </Stack>

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -38,6 +38,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
   })
 
   const canCreate = keyResultChecklist?.policy?.create === GraphQLEffect.ALLOW
+  const hasItems = checklist.length > 0
 
   const refreshChecklist = useCallback(() => {
     getChecklist({
@@ -46,8 +47,14 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
       },
     })
   }, [getChecklist, keyResultID])
+
   const toggleChecklistCollapse = () => {
     setIsChecklistOpen(!isChecklistOpen)
+  }
+
+  const handleChecklistCreation = () => {
+    refreshChecklist()
+    if (!isChecklistOpen) setIsChecklistOpen(true)
   }
 
   useEffect(() => {
@@ -63,20 +70,20 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
       <Stack direction="row" alignItems="center">
         <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
         <OptionBarWrapper
-          progress={keyResultChecklist?.progress}
-          refresh={refreshChecklist}
           keyResultID={keyResultID}
+          progress={keyResultChecklist?.progress}
           canCreate={canCreate}
+          onCreate={handleChecklistCreation}
         />
-        <ToggleCollapse isOpen={isChecklistOpen} onToggle={toggleChecklistCollapse} />
+        {hasItems && <ToggleCollapse isOpen={isChecklistOpen} onToggle={toggleChecklistCollapse} />}
       </Stack>
       {isChecklistLoaded ? (
         <Collapse in={isChecklistOpen}>
           <KeyResultChecklist
             nodes={checklist}
-            refresh={refreshChecklist}
             keyResultID={keyResultID}
             canCreate={canCreate}
+            onCreateCheckmark={refreshChecklist}
           />
         </Collapse>
       ) : (

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -1,6 +1,6 @@
 import { useLazyQuery } from '@apollo/client'
-import { Stack } from '@chakra-ui/react'
-import React, { useCallback, useEffect } from 'react'
+import { Collapse, Stack } from '@chakra-ui/react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRecoilState } from 'recoil'
 
@@ -16,12 +16,14 @@ import { KeyResultChecklist } from './checklist'
 import messages from './messages'
 import queries from './queries.gql'
 import { KeyResultChecklistSkeleton } from './skeleton'
+import { ToggleCollapse } from './toggle-collapse'
 
 interface KeyResultChecklistWrapperProperties {
   keyResultID?: string
 }
 
 export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWrapperProperties) => {
+  const [isChecklistOpen, setIsChecklistOpen] = useState(false)
   const [keyResultChecklist, setKeyResultChecklist] = useRecoilState(
     keyResultChecklistAtom(keyResultID),
   )
@@ -36,6 +38,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
   })
 
   const canCreate = keyResultChecklist?.policy?.create === GraphQLEffect.ALLOW
+
   const refreshChecklist = useCallback(() => {
     getChecklist({
       variables: {
@@ -43,6 +46,9 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
       },
     })
   }, [getChecklist, keyResultID])
+  const toggleChecklistCollapse = () => {
+    setIsChecklistOpen(!isChecklistOpen)
+  }
 
   useEffect(() => {
     if (called && !loading) updateChecklistEdges(keyResultChecklist?.edges)
@@ -62,14 +68,17 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
           keyResultID={keyResultID}
           canCreate={canCreate}
         />
+        <ToggleCollapse isOpen={isChecklistOpen} onToggle={toggleChecklistCollapse} />
       </Stack>
       {isChecklistLoaded ? (
-        <KeyResultChecklist
-          nodes={checklist}
-          refresh={refreshChecklist}
-          keyResultID={keyResultID}
-          canCreate={canCreate}
-        />
+        <Collapse in={isChecklistOpen}>
+          <KeyResultChecklist
+            nodes={checklist}
+            refresh={refreshChecklist}
+            keyResultID={keyResultID}
+            canCreate={canCreate}
+          />
+        </Collapse>
       ) : (
         <KeyResultChecklistSkeleton />
       )}

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -8,7 +8,9 @@ import { keyResultAtomFamily } from 'src/state/recoil/key-result'
 
 import { KeyResultSectionHeading } from '../Heading/wrapper'
 
+import { KeyResultChecklist } from './checklist'
 import messages from './messages'
+import { KeyResultChecklistSkeleton } from './skeleton'
 
 interface KeyResultChecklistWrapperProperties {
   keyResultID?: string
@@ -32,6 +34,11 @@ export const KeyResultChecklistWrapper = ({
   return (
     <Stack>
       <KeyResultSectionHeading>{intl.formatMessage(messages.heading)}</KeyResultSectionHeading>
+      {isLoading || !isChecklistLoaded ? (
+        <KeyResultChecklistSkeleton />
+      ) : (
+        <KeyResultChecklist nodes={checklist} />
+      )}
     </Stack>
   )
 }

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -35,7 +35,6 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
     },
   })
 
-  const isLoading = called && loading && !isChecklistLoaded
   const canCreate = keyResultChecklist?.policy?.create === GraphQLEffect.ALLOW
   const refreshChecklist = useCallback(() => {
     getChecklist({
@@ -46,8 +45,8 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
   }, [getChecklist, keyResultID])
 
   useEffect(() => {
-    updateChecklistEdges(keyResultChecklist?.edges)
-  }, [keyResultChecklist, updateChecklistEdges])
+    if (called && !loading) updateChecklistEdges(keyResultChecklist?.edges)
+  }, [called, loading, keyResultChecklist, updateChecklistEdges])
 
   useEffect(() => {
     if (keyResultID) refreshChecklist()
@@ -64,15 +63,15 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
           canCreate={canCreate}
         />
       </Stack>
-      {isLoading ? (
-        <KeyResultChecklistSkeleton />
-      ) : (
+      {isChecklistLoaded ? (
         <KeyResultChecklist
           nodes={checklist}
           refresh={refreshChecklist}
           keyResultID={keyResultID}
           canCreate={canCreate}
         />
+      ) : (
+        <KeyResultChecklistSkeleton />
       )}
     </Stack>
   )

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -1,6 +1,10 @@
 import { Stack } from '@chakra-ui/react'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
+import { useRecoilValue } from 'recoil'
+
+import { useConnectionEdges } from 'src/state/hooks/useConnectionEdges/hook'
+import { keyResultAtomFamily } from 'src/state/recoil/key-result'
 
 import { KeyResultSectionHeading } from '../Heading/wrapper'
 
@@ -15,7 +19,15 @@ export const KeyResultChecklistWrapper = ({
   keyResultID,
   isLoading,
 }: KeyResultChecklistWrapperProperties) => {
+  const keyResult = useRecoilValue(keyResultAtomFamily(keyResultID))
+  const [checklist, updateChecklistEdges, _, isChecklistLoaded] = useConnectionEdges(
+    keyResult?.checkList?.edges,
+  )
   const intl = useIntl()
+
+  useEffect(() => {
+    updateChecklistEdges(keyResult?.checkList?.edges)
+  }, [keyResult, updateChecklistEdges])
 
   return (
     <Stack>

--- a/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/wrapper.tsx
@@ -30,6 +30,7 @@ export const KeyResultChecklistWrapper = ({ keyResultID }: KeyResultChecklistWra
   const [checklist, updateChecklistEdges, _, isChecklistLoaded] =
     useConnectionEdges<KeyResultCheckMark>()
   const intl = useIntl()
+
   const [getChecklist, { called, loading }] = useLazyQuery(queries.GET_CHECKLIST_OF_KEY_RESULT, {
     fetchPolicy: 'network-only',
     onCompleted: (data) => {

--- a/src/components/KeyResult/Single/Sections/Timeline/Header/header.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Header/header.tsx
@@ -13,10 +13,12 @@ import KeyResultSectionTimelineDeleteAlert from './DeleteAlert'
 
 export interface KeyResultSectionTimelineHeaderProperties {
   keyResultID?: KeyResult['id']
+  newCheckInValue?: number
 }
 
 const KeyResultSectionTimelineHeader = ({
   keyResultID,
+  newCheckInValue,
 }: KeyResultSectionTimelineHeaderProperties) => {
   const keyResult = useRecoilValue(keyResultAtomFamily(keyResultID))
   const setLatestTimelineEntry = useSetRecoilState(selectLatestTimelineEntry(keyResultID))
@@ -43,6 +45,7 @@ const KeyResultSectionTimelineHeader = ({
       <Collapse unmountOnExit in={canUpdate} style={{ overflow: 'visible' }}>
         <KeyResultSectionAddCheckIn
           keyResultID={keyResultID}
+          newCheckInValue={newCheckInValue}
           onCompleted={handleCheckInCompleted}
         />
       </Collapse>

--- a/src/components/KeyResult/Single/Sections/Timeline/timeline.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/timeline.tsx
@@ -15,6 +15,7 @@ export interface KeyResultSectionTimelineProperties {
   limit: number
   scrollTarget: string
   keyResultID?: KeyResult['id']
+  newCheckInValue?: number
   onEntryDelete?: (entryType: string) => void
 }
 
@@ -29,6 +30,7 @@ const KeyResultSectionTimeline = ({
   limit,
   scrollTarget,
   onEntryDelete,
+  newCheckInValue,
 }: KeyResultSectionTimelineProperties) => {
   const [hasMore, setHasMore] = useState(false)
   const [timeline, setTimeline] = useRecoilState(timelineSelector(keyResultID))
@@ -76,7 +78,7 @@ const KeyResultSectionTimeline = ({
 
   return (
     <Flex direction="column" gridGap={4}>
-      <KeyResultSectionTimelineHeader keyResultID={keyResultID} />
+      <KeyResultSectionTimelineHeader keyResultID={keyResultID} newCheckInValue={newCheckInValue} />
 
       {keyResultID && hasTimeline ? (
         <KeyResultSectionTimelineContent

--- a/src/components/KeyResult/types.ts
+++ b/src/components/KeyResult/types.ts
@@ -65,7 +65,7 @@ export interface KeyResultCheckMark extends GraphQLNode {
   userId: string
 }
 
-enum KeyResultCheckMarkState {
+export enum KeyResultCheckMarkState {
   CHECKED = 'checked',
   UNCHECKED = 'unchecked',
 }

--- a/src/components/KeyResult/types.ts
+++ b/src/components/KeyResult/types.ts
@@ -57,7 +57,7 @@ interface KeyResultCheckInDelta extends Delta {
   value: number
 }
 
-interface KeyResultCheckMark extends GraphQLNode {
+export interface KeyResultCheckMark extends GraphQLNode {
   description: string
   state: KeyResultCheckMarkState
   updatedAt: string

--- a/src/components/KeyResult/types.ts
+++ b/src/components/KeyResult/types.ts
@@ -70,11 +70,11 @@ enum KeyResultCheckMarkState {
   UNCHECKED = 'unchecked',
 }
 
-interface KeyResultChecklist extends GraphQLConnection<KeyResultCheckMark> {
+export interface KeyResultChecklist extends GraphQLConnection<KeyResultCheckMark> {
   progress: KeyResultChecklistProgress
 }
 
-interface KeyResultChecklistProgress {
+export interface KeyResultChecklistProgress {
   total: number
   numberOfChecked: number
   progress: number

--- a/src/components/KeyResult/types.ts
+++ b/src/components/KeyResult/types.ts
@@ -50,8 +50,32 @@ export interface KeyResult extends GraphQLNode {
   keyResultCheckIns?: GraphQLConnection<KeyResultCheckIn>
   keyResultComments?: GraphQLConnection<KeyResultComment>
   timeline?: GraphQLConnection<KeyResultTimelineEntry>
+  checkList: KeyResultChecklist
 }
 
 interface KeyResultCheckInDelta extends Delta {
   value: number
+}
+
+interface KeyResultCheckMark extends GraphQLNode {
+  description: string
+  state: KeyResultCheckMarkState
+  updatedAt: string
+  keyResultId: string
+  userId: string
+}
+
+enum KeyResultCheckMarkState {
+  CHECKED = 'checked',
+  UNCHECKED = 'unchecked',
+}
+
+interface KeyResultChecklist extends GraphQLConnection<KeyResultCheckMark> {
+  progress: KeyResultChecklistProgress
+}
+
+interface KeyResultChecklistProgress {
+  total: number
+  numberOfChecked: number
+  progress: number
 }

--- a/src/components/Objective/Accordion/Item/Button/edit-mode.tsx
+++ b/src/components/Objective/Accordion/Item/Button/edit-mode.tsx
@@ -1,26 +1,20 @@
 import { useMutation } from '@apollo/client'
 import { Input, InputGroup } from '@chakra-ui/input'
 import { Stack } from '@chakra-ui/layout'
-import {
-  FormControl,
-  IconButton,
-  IconButtonProps,
-  InputRightElement,
-  useToast,
-} from '@chakra-ui/react'
+import { FormControl, InputRightElement, useToast } from '@chakra-ui/react'
 import { Spinner } from '@chakra-ui/spinner'
 import { Form, Formik, Field } from 'formik'
 import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { useSetRecoilState } from 'recoil'
 
+import { CancelButton } from 'src/components/Base/EditableControls/cancel-button'
+import { ConfirmButton } from 'src/components/Base/EditableControls/confirm-button'
 import { ObjectiveMode, setObjectiveToMode } from 'src/state/recoil/objective/context'
 
 import { useRecoilFamilyLoader } from '../../../../../state/recoil/hooks'
 import { objectiveAtomFamily } from '../../../../../state/recoil/objective'
 import { CancelIcon } from '../../../../Icon/Cancel/wrapper'
-import CheckIcon from '../../../../Icon/Check'
-import TimesIcon from '../../../../Icon/Times'
 import { Objective } from '../../../types'
 import { stopAccordionOpen } from '../../handlers'
 
@@ -38,18 +32,6 @@ interface EditModeProperties {
 interface UpdateObjectiveMutationResult {
   updateObjective: Partial<Objective>
 }
-
-const EditModeIconButton = (properties: IconButtonProps) => (
-  <IconButton
-    variant="solid"
-    h={12}
-    w={12}
-    fontSize="2xl"
-    bg="black.100"
-    color="gray.500"
-    {...properties}
-  />
-)
 
 export const EditMode = ({ objective }: EditModeProperties) => {
   const intl = useIntl()
@@ -136,35 +118,8 @@ export const EditMode = ({ objective }: EditModeProperties) => {
             </InputGroup>
 
             <Stack direction="row" spacing={4} alignItems="stretch">
-              <EditModeIconButton
-                aria-label={intl.formatMessage(messages.cancelButtonDesc)}
-                _hover={{
-                  color: 'white',
-                  bg: 'red.500',
-                }}
-                onClick={handleCancel}
-              >
-                <TimesIcon
-                  desc={intl.formatMessage(messages.cancelButtonDesc)}
-                  fill="currentColor"
-                />
-              </EditModeIconButton>
-
-              <EditModeIconButton
-                isLoading={loading}
-                isDisabled={Object.values(errors).length > 0}
-                aria-label={intl.formatMessage(messages.submitButtonDesc)}
-                type="submit"
-                _hover={{
-                  color: loading || Object.values(errors).length > 0 ? 'gray.500' : 'white',
-                  bg: loading || Object.values(errors).length > 0 ? 'gray.50' : 'green.500',
-                }}
-              >
-                <CheckIcon
-                  desc={intl.formatMessage(messages.submitButtonDesc)}
-                  fill="currentColor"
-                />
-              </EditModeIconButton>
+              <CancelButton onCancel={handleCancel} />
+              <ConfirmButton isLoading={loading} isDisabled={Object.values(errors).length > 0} />
             </Stack>
           </FormControl>
         </Form>

--- a/src/components/Objective/Accordion/Item/Button/messages.ts
+++ b/src/components/Objective/Accordion/Item/Button/messages.ts
@@ -6,8 +6,6 @@ type ObjectiveAccordionItemMessage =
   | 'progressTagLabel'
   | 'progressTagTooltip'
   | 'progressTooltip'
-  | 'cancelButtonDesc'
-  | 'submitButtonDesc'
   | 'submitToastMessage'
   | 'unexpectedErrorToastMessage'
   | 'requiredFieldError'
@@ -46,22 +44,6 @@ export default defineMessages<ObjectiveAccordionItemMessage>({
       'O progresso do objetivo é calculado pela média de evolução dos seus resultados-chave. É preciso atingir todos esses resultados para alcançar o objetivo. Por isso, a cor desse indicador reflete a menor confiança entre seus resultados-chave.',
     id: 'kFrglO',
     description: 'This tooltip explains how the progress of the objective is calculated',
-  },
-
-  cancelButtonDesc: {
-    defaultMessage:
-      'Um botão com um ícone de X. Ao clicar nele você irá cancelar a atualização do objetivo',
-    id: 'npWxt7',
-    description:
-      'This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the cancel button',
-  },
-
-  submitButtonDesc: {
-    defaultMessage:
-      'Um botão com um ícone de confirmação. Ao clicar nele você irá salvar sua atualização do objetivo',
-    id: 'xfx/rc',
-    description:
-      'This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the check button',
   },
 
   submitToastMessage: {

--- a/src/components/Objective/Accordion/Item/Panel/queries.gql
+++ b/src/components/Objective/Accordion/Item/Panel/queries.gql
@@ -1,7 +1,7 @@
 query GET_OBJECTIVE_KEY_RESULTS($objectiveID: ID!) {
   objective(id: $objectiveID) {
     id
-    keyResults {
+    keyResults(order: { createdAt: ASC }) {
       edges {
         node {
           id

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -13,6 +13,7 @@ export interface GraphQLEdge<N extends GraphQLNode> {
 export interface GraphQLNode {
   id: string
   createdAt: string
+  policy: GraphQLEntityPolicy
 }
 
 export interface GraphQLConnectionPolicy {

--- a/src/state/hooks/useAmplitude/marshal-amplitude-user.ts
+++ b/src/state/hooks/useAmplitude/marshal-amplitude-user.ts
@@ -1,5 +1,4 @@
 import { USER_GENDER } from '../../../components/User/constants'
-import { GraphQLConnection, GraphQLEdge } from '../../../components/types'
 
 import { AmplitudeUser, AmplitudeUserGroups } from './types'
 
@@ -10,14 +9,22 @@ type MinimumUser = {
   gender: USER_GENDER
   role: string
   createdAt: string
-  companies: GraphQLConnection<MinimumGroup>
-  teams: GraphQLConnection<MinimumGroup>
+  companies: MinimumConnection<MinimumGroup>
+  teams: MinimumConnection<MinimumGroup>
 }
 
-interface MinimumGroup {
+type MinimumGroup = {
   id: string
   name: string
   createdAt: string
+}
+
+type MinimumConnection<N> = {
+  edges: Array<MinimumEdge<N>>
+}
+
+type MinimumEdge<N> = {
+  node: N
 }
 
 export const marshalAmplitudeUser = (user: MinimumUser): AmplitudeUser => ({
@@ -34,5 +41,5 @@ export const marshalAmplitudeUserGroups = (user: MinimumUser): AmplitudeUserGrou
   teams: getGroupNames(user.teams.edges),
 })
 
-const getGroupNames = (groupEdges: Array<GraphQLEdge<MinimumGroup>>): string[] =>
+const getGroupNames = (groupEdges: Array<MinimumEdge<MinimumGroup>>): string[] =>
   groupEdges.map((edge) => edge.node.name)

--- a/src/state/recoil/key-result/checklist.ts
+++ b/src/state/recoil/key-result/checklist.ts
@@ -18,3 +18,8 @@ export const draftCheckMarksAtom = atomFamily<string[], string | undefined>({
   key: `${key}::DRAFT_CHECK_MARKS`,
   default: [],
 })
+
+export const checkMarkIsBeingRemovedAtom = atomFamily<boolean, string | undefined>({
+  key: `${key}::IS_BEING_REMOVED`,
+  default: false,
+})

--- a/src/state/recoil/key-result/checklist.ts
+++ b/src/state/recoil/key-result/checklist.ts
@@ -4,7 +4,7 @@ import { KeyResultChecklist } from 'src/components/KeyResult/types'
 
 import { PREFIX } from './constants'
 
-const key = `${PREFIX}`
+const key = `${PREFIX}::CHECKLIST`
 
 export const keyResultChecklistAtom = atomFamily<
   KeyResultChecklist | undefined,
@@ -12,4 +12,9 @@ export const keyResultChecklistAtom = atomFamily<
 >({
   key,
   default: undefined,
+})
+
+export const draftCheckMarksAtom = atomFamily<string[], string | undefined>({
+  key: `${key}::DRAFT_CHECK_MARKS`,
+  default: [],
 })

--- a/src/state/recoil/key-result/checklist.ts
+++ b/src/state/recoil/key-result/checklist.ts
@@ -1,0 +1,15 @@
+import { atomFamily } from 'recoil'
+
+import { KeyResultChecklist } from 'src/components/KeyResult/types'
+
+import { PREFIX } from './constants'
+
+const key = `${PREFIX}`
+
+export const keyResultChecklistAtom = atomFamily<
+  KeyResultChecklist | undefined,
+  string | undefined
+>({
+  key,
+  default: undefined,
+})

--- a/src/themes/preset-base/components/checkbox.ts
+++ b/src/themes/preset-base/components/checkbox.ts
@@ -1,0 +1,20 @@
+export const Checkbox = {
+  baseStyle: {
+    control: {
+      p: 3,
+      borderRadius: 6,
+      borderColor: 'gray.100',
+      borderWidth: 1,
+
+      '&[data-checked]': {
+        bg: 'brand.500',
+        borderColor: 'brand.500',
+
+        '&[data-hover]': {
+          bg: 'brand.500',
+          borderColor: 'brand.500',
+        },
+      },
+    },
+  },
+}

--- a/src/themes/preset-base/components/checkbox.ts
+++ b/src/themes/preset-base/components/checkbox.ts
@@ -6,6 +6,10 @@ export const Checkbox = {
       borderColor: 'gray.100',
       borderWidth: 1,
 
+      '&[data-focus]': {
+        boxShadow: 'none',
+      },
+
       '&[data-checked]': {
         bg: 'brand.500',
         borderColor: 'brand.500',

--- a/src/themes/preset-base/components/checkbox.ts
+++ b/src/themes/preset-base/components/checkbox.ts
@@ -16,5 +16,12 @@ export const Checkbox = {
         },
       },
     },
+
+    label: {
+      '&[data-checked]': {
+        color: 'new-gray.600',
+        textDecoration: 'line-through',
+      },
+    },
   },
 }

--- a/src/themes/preset-base/components/checkbox.ts
+++ b/src/themes/preset-base/components/checkbox.ts
@@ -15,6 +15,21 @@ export const Checkbox = {
           borderColor: 'brand.500',
         },
       },
+
+      '&[data-disabled]': {
+        bg: 'white',
+
+        '&[data-checked]': {
+          bg: 'brand.500',
+          borderColor: 'brand.500',
+          color: 'white',
+
+          '&[data-hover]': {
+            bg: 'brand.500',
+            borderColor: 'brand.500',
+          },
+        },
+      },
     },
 
     label: {

--- a/src/themes/preset-base/components/index.ts
+++ b/src/themes/preset-base/components/index.ts
@@ -27,3 +27,5 @@ export { default as Tabs } from './tabs'
 export { default as Drawer } from './drawer'
 
 export { default as Link } from './link'
+
+export { Checkbox } from './checkbox'

--- a/src/themes/preset-base/theme.ts
+++ b/src/themes/preset-base/theme.ts
@@ -18,6 +18,7 @@ import {
   Tabs,
   Drawer,
   Link,
+  Checkbox,
 } from './components'
 
 const colors = {
@@ -185,6 +186,7 @@ const theme = extendTheme({
     Tabs,
     Drawer,
     Link,
+    Checkbox,
   },
 
   fonts: {


### PR DESCRIPTION
## ☕ Purpose

This PR integrates with [business#129](https://github.com/budproj/business/pull/129) and adds the checklist feature inside our Key-Result sidebar.

## 🧐 Checklist

- [x] Adds the wrapper component of the sidebar;
- [x] Configure the heading and basic structure;
- [x] Adds the basic checkbox listing structure;
- [x] Customize the checkbox style;
- [x] Adds the checkbox skeleton and checklist skeleton;
- [x] Adds the x/y marker in the checklist title, alongside with its skeleton;
- [x] Adds the progress bar of the checklist, alongisde with its skeleton;
- [x] Adds the toggle behaviour to the checklist;
- [x] Adds loading while toggling;
- [x] Fixes the progress that is not being updated upon toggle;
- [x] Adds the insert checkmark button, which should only appear if there are already a checklist for that KR;
- [x] Updates when the user insert a new check-mark to open it in edit mode;
- [x] Updates to focus automatically when adding new check marks
- [x] Adds the empty-state insert checklist button, which should hide if there are checkmarks in that KR;
- [x] Hides the checklist insert buttons if the user is not allowed to create a checklist;
- [x] Don't allow the user to check if it can't update the checkmark;
- [x] Insert the remove checkmark button;
- [x] Hides the remove checkmark button if the user is not allowed to delete a checkmark;
- [x] Insert the editable input to enable editing a given checkmark contents;
- [x] Block checkmark description edition if the user is not allowed to update a checkmark;
- [x] Edits the editable input to add the buttons.

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:
* [business#129](https://github.com/budproj/business/pull/129)
