### PR TITLE
Feat: subteams search box

### DIFF
--- a/src/components/Page/Team/ChildTeams/messages.ts
+++ b/src/components/Page/Team/ChildTeams/messages.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl'
 
-type ExploreTeamChildTeamsMessage = 'title' | 'emptyState'
+type ExploreTeamChildTeamsMessage = 'title' | 'emptyState' | 'searchPlaceholder'
 
 export default defineMessages<ExploreTeamChildTeamsMessage>({
   title: {
@@ -14,5 +14,11 @@ export default defineMessages<ExploreTeamChildTeamsMessage>({
     id: 'DsPsDZ',
     description:
       'This message is displayed in our team plage inside the child teams section when that team has no child teams',
+  },
+
+  searchPlaceholder: {
+    defaultMessage: 'Buscar subtimes',
+    id: '/H4hHb',
+    description: 'This message is displayed inside the child teams section, on the search bar',
   },
 })

--- a/src/components/Page/Team/ChildTeams/team-list-searchable.tsx
+++ b/src/components/Page/Team/ChildTeams/team-list-searchable.tsx
@@ -1,0 +1,38 @@
+import React, { useContext } from 'react'
+import { useIntl } from 'react-intl'
+
+import { SearchableList } from 'src/components/Base/SearchableList'
+import { SearchableListContext } from 'src/components/Base/SearchableList/context'
+import { TeamList } from 'src/components/Team/List/wrapper'
+import { Team } from 'src/components/Team/types'
+
+import messages from './messages'
+
+interface TeamListSearchableProperties {
+  teams: Team[]
+  isLoading: boolean
+}
+
+interface TeamsInContextProperties {
+  isLoading: boolean
+}
+
+const TeamsInContext = ({ isLoading }: TeamsInContextProperties) => {
+  const { items } = useContext(SearchableListContext)
+
+  return <TeamList teams={items} isLoading={isLoading} />
+}
+
+export const TeamListSearchable = ({ teams, isLoading }: TeamListSearchableProperties) => {
+  const intl = useIntl()
+
+  return (
+    <SearchableList
+      placeholder={intl.formatMessage(messages.searchPlaceholder)}
+      searchKey="name"
+      initialItems={teams}
+    >
+      <TeamsInContext isLoading={isLoading} />
+    </SearchableList>
+  )
+}

--- a/src/components/Page/Team/ChildTeams/wrapper.tsx
+++ b/src/components/Page/Team/ChildTeams/wrapper.tsx
@@ -6,11 +6,11 @@ import { useConnectionEdges } from '../../../../state/hooks/useConnectionEdges/h
 import { useRecoilFamilyLoader } from '../../../../state/recoil/hooks'
 import { teamAtomFamily } from '../../../../state/recoil/team'
 import { EmptyState } from '../../../Base'
-import { TeamList } from '../../../Team/List/wrapper'
 import { Team } from '../../../Team/types'
 import { TeamSectionWrapper } from '../Section/wrapper'
 
 import messages from './messages'
+import { TeamListSearchable } from './team-list-searchable'
 
 interface ChildTeamsWrapperProperties {
   teamID?: string
@@ -51,7 +51,7 @@ export const ChildTeamsWrapper = ({ teamID, isLoading }: ChildTeamsWrapperProper
       {isLoaded && childTeams.length === 0 ? (
         <EmptyState imageKey="empty-folder" labelMessage={messages.emptyState} py={8} />
       ) : (
-        <TeamList teams={childTeams} isLoading={!isLoaded} />
+        <TeamListSearchable teams={childTeams} isLoading={!isLoaded} />
       )}
     </TeamSectionWrapper>
   )


### PR DESCRIPTION
## ☕ Purpose

Adds a search box for subteams, on Team page.

## 🧐 Checklist

- [x] split TeamList component to a subcomponent
- [x] add SearchableList to component
- [x] use SearchableList context to render TeamList
- [x] add intl