### PR TITLE
Feat: auth subdomain stable

### DIFF
--- a/manifests/stable/deployment.yaml
+++ b/manifests/stable/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: AUTH0_CLIENT_ID_PUBLIC
               value: 76DivGrWIbmLh7V2SkFyPeIbUFN6OBf3
             - name: AUTH0_DOMAIN
-              value: getbud.us.auth0.com
+              value: auth.getbud.co
             - name: AUTH0_SCOPE
               value: openid profile
             - name: AUTH0_AUDIENCE


### PR DESCRIPTION
## ☕ Purpose

This PR works together with auth0 new configuration to allow logins from domain `auth.getbud.co`.

## 🧐 Checklist

- [x] Change auth0 domain variable

## 🍩 Further details

- https://auth0.com/docs/brand-and-customize/custom-domains/auth0-managed-certificates

