### PR TITLE
Disable users card on team page

### DIFF
--- a/src/components/Page/Team/Members/members.tsx
+++ b/src/components/Page/Team/Members/members.tsx
@@ -85,7 +85,6 @@ export const TeamMembers = ({
       })}
     >
       <SelectUserfromList
-        showUserCard
         teamID={teamID}
         users={members}
         avatarSubtitleType="role"


### PR DESCRIPTION
## ☕ Purpose

Disable user's card on the teams' page

## 🧐 Checklist

- [x] Disable user's card on the teams' page

## 🐞 Testing

Go to the Teams page and hover over a user name, the card should not be loaded.