### PR TITLE
bugfix(team/select): not listing all teams

### DIFF
--- a/src/components/Team/Select/queries.gql
+++ b/src/components/Team/Select/queries.gql
@@ -1,5 +1,5 @@
 query GET_REACHABLE_TEAMS {
-  teams {
+  teams(first: 1000) {
     edges {
       node {
         id


### PR DESCRIPTION
## ☕ Purpose

In explore team page, we do not get all teams listed in the root team.

A temporary solution is only change the limit of teams to get from graphql. (by default is 20)

A more robust solution is needed. Fixing pagination in the backend and modify the components to fetch each page when needed is the correct solution to aim for.