### PR TITLE
Add scroll option to team list

### DIFF
--- a/src/components/Team/Select/styled-wrapper.tsx
+++ b/src/components/Team/Select/styled-wrapper.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled'
+import React, { ReactElement } from 'react'
+
+const StyledTeamWrapper = styled.div`
+  max-height: 250px;
+  overflow-y: auto;
+  margin-top: 10px;
+
+  &::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #cecece;
+    border: 0px none #ffffff;
+    border-radius: 50px;
+  }
+`
+
+type StyledTeamSelectWrapperProperties = {
+  children: ReactElement[]
+  hasScroll?: boolean
+}
+
+export const StyledTeamSelectWrapper = ({
+  hasScroll,
+  children,
+}: StyledTeamSelectWrapperProperties) => {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return hasScroll ? <StyledTeamWrapper>{children}</StyledTeamWrapper> : <>{children}</>
+}

--- a/src/components/Team/Select/wrapper.tsx
+++ b/src/components/Team/Select/wrapper.tsx
@@ -8,6 +8,7 @@ import { useConnectionEdges } from 'src/state/hooks/useConnectionEdges/hook'
 import { Team } from '../types'
 
 import queries from './queries.gql'
+import { StyledTeamSelectWrapper } from './styled-wrapper'
 
 type TeamData = {
   id: string
@@ -15,6 +16,7 @@ type TeamData = {
 }
 
 type TeamTagListProperties = {
+  hasScroll?: boolean
   filter?: string
   teams?: TeamData[]
   teamIDsBlacklist?: string[]
@@ -26,6 +28,7 @@ type GetReachableTeamsResponse = {
 }
 
 export const TeamSelect = ({
+  hasScroll,
   filter,
   teams,
   teamIDsBlacklist,
@@ -66,7 +69,7 @@ export const TeamSelect = ({
   }, [isLoaded, teams, getReachableTeams])
 
   return (
-    <>
+    <StyledTeamSelectWrapper hasScroll={hasScroll}>
       {filteredTeams.map((team) => (
         <MenuItem
           key={team.id}
@@ -86,6 +89,6 @@ export const TeamSelect = ({
           {team.name}
         </MenuItem>
       ))}
-    </>
+    </StyledTeamSelectWrapper>
   )
 }

--- a/src/components/User/Teams/add-team.tsx
+++ b/src/components/User/Teams/add-team.tsx
@@ -68,7 +68,12 @@ export const AddUserTeam = ({ userID, teamIDsBlacklist }: AddUserTeamProperties)
       </MenuButton>
       <MenuList p={4} boxShadow="with-stroke.light" borderColor="new-gray.200" borderWidth={1}>
         <TeamSearch onSearch={handleSearch} />
-        <TeamSelect teamIDsBlacklist={teamIDsBlacklist} filter={filter} onSelect={handleSelect} />
+        <TeamSelect
+          hasScroll
+          teamIDsBlacklist={teamIDsBlacklist}
+          filter={filter}
+          onSelect={handleSelect}
+        />
       </MenuList>
     </Menu>
   )


### PR DESCRIPTION
## ☕ Purpose

Prevent team list to overflow the drawer creating a new hasScroll flag.

## 🧐 Checklist

- [x] Add scroll option to team list

## 🐞 Testing

Open the team list on the user options and it should have a scroll.
