### PR TITLE
bugfix(components/kr/checklist): list first 1000 checkmarks instead of 20, by default

### DIFF
--- a/src/components/KeyResult/Single/Sections/Checklist/queries.gql
+++ b/src/components/KeyResult/Single/Sections/Checklist/queries.gql
@@ -1,7 +1,7 @@
 query GET_CHECKLIST_OF_KEY_RESULT($id: ID!) {
   keyResult(id: $id) {
     id
-    checkList {
+    checkList(first: 1000) {
       policy {
         create
       }


### PR DESCRIPTION
## ☕ Purpose
Resolves a problem with some clients creating checkmarks but not able to see them.