### PR TITLE
[WIP] users objectives

### DIFF
--- a/src/components/Cycle/Objectives/wrapper.tsx
+++ b/src/components/Cycle/Objectives/wrapper.tsx
@@ -2,9 +2,12 @@ import { Stack, Heading, Skeleton } from '@chakra-ui/react'
 import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
 
+import { ObjectiveAccordion } from 'src/components/Objective/Accordion/wrapper'
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
+
 import buildSkeletonMinSize from '../../../../lib/chakra/build-skeleton-min-size'
 import useCadence from '../../../state/hooks/useCadence'
-import { ObjectiveAccordion } from '../../Objective/Accordion/wrapper'
 import { Cycle } from '../types'
 
 import messages from './messages'
@@ -12,7 +15,8 @@ import messages from './messages'
 export interface ObjectivesFromCycleProperties {
   cycle?: Cycle
   objectiveIDs: string[]
-  teamID?: string
+  teamID?: Team['id']
+  userID?: User['id']
   isDisabled?: boolean
 }
 
@@ -20,6 +24,7 @@ export const CycleObjectives = ({
   cycle,
   objectiveIDs,
   teamID,
+  userID,
   isDisabled,
 }: ObjectivesFromCycleProperties) => {
   const intl = useIntl()
@@ -51,6 +56,7 @@ export const CycleObjectives = ({
         isLoaded={isLoaded}
         objectiveIDs={objectiveIDs}
         teamID={teamID}
+        userID={userID}
         accordionID={cycle?.id}
         isDisabled={isDisabled}
       />

--- a/src/components/Objective/Accordion/Item/Button/view-mode.tsx
+++ b/src/components/Objective/Accordion/Item/Button/view-mode.tsx
@@ -2,6 +2,9 @@ import { Stack, AccordionIcon, Heading, Skeleton } from '@chakra-ui/react'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
+
 import buildSkeletonMinSize from '../../../../../../lib/chakra/build-skeleton-min-size'
 import { PercentageProgressIncreaseTag } from '../../../../Base'
 import TooltipWithDelay from '../../../../Base/TooltipWithDelay'
@@ -13,11 +16,18 @@ import messages from './messages'
 interface ViewModeProperties {
   isLoaded?: boolean
   objective?: Partial<Objective>
-  teamID?: string
+  userID?: User['id']
+  teamID?: Team['id']
   isDisabled?: boolean
 }
 
-export const ViewMode = ({ objective, isLoaded, teamID, isDisabled }: ViewModeProperties) => {
+export const ViewMode = ({
+  objective,
+  isLoaded,
+  userID,
+  teamID,
+  isDisabled,
+}: ViewModeProperties) => {
   const intl = useIntl()
 
   return (
@@ -71,6 +81,7 @@ export const ViewMode = ({ objective, isLoaded, teamID, isDisabled }: ViewModePr
 
             <ObjectiveAccordionMenu
               teamID={teamID}
+              userID={userID}
               objectiveID={objective?.id}
               isLoaded={isLoaded}
             />

--- a/src/components/Objective/Accordion/Item/Button/wrapper.tsx
+++ b/src/components/Objective/Accordion/Item/Button/wrapper.tsx
@@ -5,6 +5,8 @@ import { useRecoilValue } from 'recoil'
 
 import TooltipWithDelay from 'src/components/Base/TooltipWithDelay'
 import { Objective } from 'src/components/Objective/types'
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
 import { ConfidenceTag } from 'src/state/hooks/useConfidenceTag/hook'
 import { objectiveContext, ObjectiveMode } from 'src/state/recoil/objective/context'
 
@@ -16,7 +18,8 @@ import { ViewMode } from './view-mode'
 
 export interface ObjectiveAccordionButtonProperties {
   objective?: Partial<Objective>
-  teamID?: string
+  userID?: User['id']
+  teamID?: Team['id']
   confidenceTag?: ConfidenceTag
   isLoaded?: boolean
   isDisabled?: boolean
@@ -24,6 +27,7 @@ export interface ObjectiveAccordionButtonProperties {
 
 export const ObjectiveAccordionButton = ({
   objective,
+  userID,
   teamID,
   confidenceTag,
   isLoaded,
@@ -58,6 +62,7 @@ export const ObjectiveAccordionButton = ({
           <ViewMode
             isLoaded={isLoaded}
             teamID={teamID}
+            userID={userID}
             objective={objective}
             isDisabled={isDisabled}
           />

--- a/src/components/Objective/Accordion/Item/Panel/wrapper.tsx
+++ b/src/components/Objective/Accordion/Item/Panel/wrapper.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { useRecoilValue } from 'recoil'
 
 import { Objective } from 'src/components/Objective/types'
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
 import { objectiveContext } from 'src/state/recoil/objective/context'
 
 import { ObjectiveKeyResults } from './key-results'
@@ -10,7 +12,8 @@ import { ObjectiveKeyResults } from './key-results'
 export interface ObjectiveAccordionPanelProperties {
   isExpanded: boolean
   objectiveID?: Objective['id']
-  teamID?: string
+  userID?: User['id']
+  teamID?: Team['id']
   isDisabled?: boolean
 }
 

--- a/src/components/Objective/Accordion/Item/wrapper.tsx
+++ b/src/components/Objective/Accordion/Item/wrapper.tsx
@@ -3,6 +3,8 @@ import React, { useEffect } from 'react'
 import { useRecoilValue } from 'recoil'
 
 import { Objective } from 'src/components/Objective/types'
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
 import useConfidenceTag from 'src/state/hooks/useConfidenceTag'
 import { objectiveAtomFamily } from 'src/state/recoil/objective'
 
@@ -11,13 +13,15 @@ import { ObjectiveAccordionPanel } from './Panel/wrapper'
 
 export interface ObjectiveAccordionItemProperties {
   objectiveID?: Objective['id']
-  teamID?: string
+  userID?: User['id']
+  teamID?: Team['id']
   isDisabled?: boolean
 }
 
 export const ObjectiveAccordionItem = ({
   objectiveID,
   teamID,
+  userID,
   isDisabled,
 }: ObjectiveAccordionItemProperties) => {
   const objective = useRecoilValue(objectiveAtomFamily(objectiveID))
@@ -43,6 +47,7 @@ export const ObjectiveAccordionItem = ({
             objective={objective}
             confidenceTag={confidenceTag}
             teamID={teamID}
+            userID={userID}
             isLoaded={isLoaded}
             isDisabled={isDisabled}
           />
@@ -50,6 +55,7 @@ export const ObjectiveAccordionItem = ({
             isExpanded={isExpanded}
             objectiveID={objectiveID}
             teamID={teamID}
+            userID={userID}
             isDisabled={isDisabled}
           />
         </>

--- a/src/components/Objective/Accordion/Menu/wrapper.tsx
+++ b/src/components/Objective/Accordion/Menu/wrapper.tsx
@@ -4,6 +4,9 @@ import { useIntl } from 'react-intl'
 import { useRecoilValue } from 'recoil'
 
 import TreeDotsIcon from 'src/components/Icon/TreeDots'
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
+import { userAtomFamily } from 'src/state/recoil/user'
 
 import { objectiveAtomFamily } from '../../../../state/recoil/objective'
 import { teamAtomFamily } from '../../../../state/recoil/team'
@@ -16,21 +19,25 @@ import { DeleteObjectiveOption } from './option-delete-objective'
 import { UpdateObjectiveOption } from './option-update-objective'
 
 interface ObjectiveAccordionMenuProperties {
-  teamID?: string
+  teamID?: Team['id']
+  userID?: User['id']
   objectiveID?: string
   isLoaded?: boolean
 }
 
 export const ObjectiveAccordionMenu = ({
   teamID,
+  userID,
   objectiveID,
   isLoaded,
 }: ObjectiveAccordionMenuProperties) => {
   const intl = useIntl()
   const team = useRecoilValue(teamAtomFamily(teamID))
+  const user = useRecoilValue(userAtomFamily(userID))
   const objective = useRecoilValue(objectiveAtomFamily(objectiveID))
 
-  const canCreateKeyResult = team?.keyResults?.policy?.create === GraphQLEffect.ALLOW
+  const policyHolder = userID ? user : team
+  const canCreateKeyResult = policyHolder?.keyResults?.policy?.create === GraphQLEffect.ALLOW
   const canUpdateObjective = objective?.policy?.update === GraphQLEffect.ALLOW
   const canDeleteObjective = objective?.policy?.delete === GraphQLEffect.ALLOW
   const hasAnyOptions = !isLoaded || canCreateKeyResult || canUpdateObjective || canDeleteObjective

--- a/src/components/Objective/Accordion/wrapper.tsx
+++ b/src/components/Objective/Accordion/wrapper.tsx
@@ -2,6 +2,8 @@ import { Accordion } from '@chakra-ui/react'
 import React, { useEffect } from 'react'
 import { useRecoilState } from 'recoil'
 
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
 import {
   objectiveAccordion,
   objectiveAccordionExpandedIndexes,
@@ -14,13 +16,15 @@ interface ObjectiveAccordionProperties {
   isLoaded: boolean
   objectiveIDs: string[]
   accordionID?: string
-  teamID?: string
+  userID?: User['id']
+  teamID?: Team['id']
   isDisabled?: boolean
 }
 
 export const ObjectiveAccordion = ({
   isLoaded,
   objectiveIDs,
+  userID,
   teamID,
   accordionID,
   isDisabled,
@@ -50,6 +54,7 @@ export const ObjectiveAccordion = ({
             key={objectiveID}
             objectiveID={objectiveID}
             teamID={teamID}
+            userID={userID}
             isDisabled={isDisabled}
           />
         ))

--- a/src/components/Objective/OKRsEmptyState/messages.ts
+++ b/src/components/Objective/OKRsEmptyState/messages.ts
@@ -1,0 +1,44 @@
+import { defineMessages } from 'react-intl'
+
+type TeamActiveObjectivesMessages =
+  | 'emptyStateTitle'
+  | 'emptyStateMessage'
+  | 'draftObjectiveTitle'
+  | 'draftObjectiveSuccessToastMessage'
+  | 'draftObjectiveErrorToastMessage'
+
+export default defineMessages<TeamActiveObjectivesMessages>({
+  emptyStateTitle: {
+    defaultMessage: 'OKRs',
+    id: '39q6ig',
+    description:
+      'This message is displayed above the empty state inside the active cycles section at the Team page',
+  },
+
+  emptyStateMessage: {
+    defaultMessage: 'Este time não possui OKRs',
+    id: 'R8hOYh',
+    description: 'This message is displayed as the empty state message inside the team page',
+  },
+
+  draftObjectiveTitle: {
+    defaultMessage: 'Novo objetivo',
+    id: '6Syzud',
+    description:
+      'This message is used as the draft title of a new objective when an objective is created inside the team page',
+  },
+
+  draftObjectiveSuccessToastMessage: {
+    defaultMessage: 'Um novo objetivo foi criado com sucesso',
+    id: 'QRy8b9',
+    description:
+      'This message appears as a toast as soon as the the user clicks to add a new objective in the team page',
+  },
+
+  draftObjectiveErrorToastMessage: {
+    defaultMessage: 'Houve um erro inesperado ao criar seu objetivo. Tente novamente mais tarde',
+    id: 'i9bdpU',
+    description:
+      'This message appears as an error toast when the users tries to create a new objective but an error appears',
+  },
+})

--- a/src/components/Objective/OKRsEmptyState/queries.gql
+++ b/src/components/Objective/OKRsEmptyState/queries.gql
@@ -1,0 +1,28 @@
+mutation CREATE_DRAFT_OBJECTIVE($title: String!, $teamID: ID!, $cycleID: ID! $ownerID: ID!) {
+  createObjective(data: {
+    title: $title,
+    teamId: $teamID,
+    cycleId: $cycleID,
+    ownerId: $ownerID,
+  }) {
+    id
+    title
+    cycle {
+      id
+      period
+      cadence
+      dateEnd
+    }
+    status {
+      progress
+      confidence
+    }
+    delta {
+      progress
+    }
+    policy {
+      update
+      delete
+    }
+  }
+}

--- a/src/components/Objective/OKRsEmptyState/wrapper.tsx
+++ b/src/components/Objective/OKRsEmptyState/wrapper.tsx
@@ -1,0 +1,111 @@
+import { useMutation } from '@apollo/client'
+import { Flex, Stack, Heading, useToast } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
+
+import { Action, ActionMenu } from 'src/components/Cycle/ActionMenu/wrapper'
+import { Cycle } from 'src/components/Cycle/types'
+import { Team } from 'src/components/Team/types'
+import { User } from 'src/components/User/types'
+import { Delta, GraphQLEntityPolicy, Status } from 'src/components/types'
+import { ObjectiveMode, setObjectiveToMode } from 'src/state/recoil/objective/context'
+import meAtom from 'src/state/recoil/user/me'
+
+import { EmptyState } from '../../Base'
+
+import messages from './messages'
+import queries from './queries.gql'
+
+type OKRsEmptyStateProperties = {
+  teamID: Team['id']
+  userID: User['id']
+  isAllowedToCreateObjectives?: boolean
+  onViewOldCycles?: Action
+  onNewObjective?: Action
+}
+
+type CreateDraftObjectiveQueryResult = {
+  createObjective: {
+    id: string
+    title: string
+    cycle: Cycle
+    status: Status
+    delta: Delta
+    policy: GraphQLEntityPolicy
+  }
+}
+
+export const OKRsEmptyState = ({
+  teamID,
+  userID,
+  onViewOldCycles,
+  onNewObjective,
+  isAllowedToCreateObjectives,
+}: OKRsEmptyStateProperties) => {
+  const intl = useIntl()
+  const toast = useToast()
+  const ownerID = useRecoilValue(meAtom)
+  const setObjectiveIDToEditMode = useSetRecoilState(setObjectiveToMode(ObjectiveMode.EDIT))
+
+  const [createDraftObjective] = useMutation<CreateDraftObjectiveQueryResult>(
+    queries.CREATE_DRAFT_OBJECTIVE,
+    {
+      variables: {
+        title: intl.formatMessage(messages.draftObjectiveTitle),
+        ownerID: userID ?? ownerID,
+        teamID,
+      },
+      onCompleted: async (data) => {
+        toast({
+          title: intl.formatMessage(messages.draftObjectiveSuccessToastMessage),
+          status: 'success',
+        })
+
+        setObjectiveIDToEditMode(data.createObjective.id)
+        if (onNewObjective) void onNewObjective()
+      },
+      onError: () => {
+        toast({
+          title: intl.formatMessage(messages.draftObjectiveErrorToastMessage),
+          status: 'error',
+        })
+      },
+    },
+  )
+
+  const handleDraftObjectiveCreation = (cycleID?: string) => {
+    void createDraftObjective({
+      variables: {
+        cycleID,
+      },
+    })
+  }
+
+  const shouldDisplayActionMenu = Boolean(onViewOldCycles) || Boolean(isAllowedToCreateObjectives)
+
+  return (
+    <Stack spacing={4} h="full">
+      <Stack direction="row" alignItems="center">
+        <Heading fontSize="sm" color="gray.500" textTransform="uppercase" flexGrow={1}>
+          {intl.formatMessage(messages.emptyStateTitle)}
+        </Heading>
+
+        {shouldDisplayActionMenu && (
+          <ActionMenu
+            onViewOldCycles={onViewOldCycles}
+            onCreateOKR={isAllowedToCreateObjectives ? handleDraftObjectiveCreation : undefined}
+          />
+        )}
+      </Stack>
+
+      <Flex bg="white" w="full" h="full" alignContent="center" justifyContent="center" p={16}>
+        <EmptyState
+          imageKey="people-with-pages"
+          labelMessage={messages.emptyStateMessage}
+          maxW="md"
+        />
+      </Flex>
+    </Stack>
+  )
+}

--- a/src/components/Objective/OKRsSkeleton/wrapper.tsx
+++ b/src/components/Objective/OKRsSkeleton/wrapper.tsx
@@ -1,0 +1,20 @@
+import uniqueId from 'lodash/uniqueId'
+import React from 'react'
+
+import { CycleObjectives } from '../../Cycle/Objectives/wrapper'
+
+export interface ChildObjectivesSkeletonProperties {
+  numOfSkeletons?: number
+}
+
+export const OKRsSkeleton = ({ numOfSkeletons }: ChildObjectivesSkeletonProperties) => {
+  numOfSkeletons ??= 1
+
+  return (
+    <>
+      {[...new Array(numOfSkeletons)].map((_) => (
+        <CycleObjectives key={uniqueId()} objectiveIDs={[]} />
+      ))}
+    </>
+  )
+}

--- a/src/components/Page/MyThings/ActiveCycles/active-cycles.tsx
+++ b/src/components/Page/MyThings/ActiveCycles/active-cycles.tsx
@@ -18,13 +18,13 @@ import { useRecoilValue, useSetRecoilState } from 'recoil'
 import { PageMetaHead } from 'src/components/Base'
 import PageContent from 'src/components/Base/PageContent'
 import { ChevronDown } from 'src/components/Icon'
-import KeyResultsActiveAndOwnedByUser from 'src/components/KeyResult/ActiveAndOwnedByUser'
 import { KeyResultSingleDrawer } from 'src/components/KeyResult/Single'
-import { KeyResult } from 'src/components/KeyResult/types'
 import { TASK_STATUS } from 'src/components/Task/constants'
 import { DetailedHeader } from 'src/components/User/DetailedHeader'
+import { UserObjectives } from 'src/components/User/Objectives/wrapper'
 import { keyResultReadDrawerOpenedKeyResultID } from 'src/state/recoil/key-result/drawers/read/opened-key-result-id'
 import { myThingsTasksQuery } from 'src/state/recoil/task'
+import { ObjectivesViewMode } from 'src/state/recoil/team/objectives-view-mode'
 import meAtom from 'src/state/recoil/user/me'
 import selectUser from 'src/state/recoil/user/selector'
 
@@ -48,7 +48,7 @@ const ActiveCyclesPage = () => {
 
   const [taskState, setTaskState] = useState(TASK_STATUS.CHECKED)
 
-  const handleLineClick = (id: KeyResult['id']) => setOpenDrawer(id)
+  // Const handleLineClick = (id: KeyResult['id']) => setOpenDrawer(id)
 
   const handleTaskFilterChange = (taskState: TASK_STATUS) => {
     setTaskState(taskState)
@@ -147,7 +147,12 @@ const ActiveCyclesPage = () => {
         <HStack align="stretch" spacing="4rem" flex="1">
           <Box flexBasis="60%" maxWidth="60%">
             {userID ? (
-              <KeyResultsActiveAndOwnedByUser userID={userID} onLineClick={handleLineClick} />
+              // <KeyResultsActiveAndOwnedByUser userID={userID} onLineClick={handleLineClick} />
+              <UserObjectives
+                userID={userID}
+                teamID="92c82e64-836c-44a5-a8c1-0db63cd340b3"
+                viewType={ObjectivesViewMode.ACTIVE}
+              />
             ) : undefined}
           </Box>
 

--- a/src/components/User/ActiveObjectives/queries.gql
+++ b/src/components/User/ActiveObjectives/queries.gql
@@ -1,0 +1,28 @@
+query GET_OBJECTIVES($ownerId: ID, $teamId: ID, $active: Boolean) {
+  objectives(ownerId: $ownerId, teamId: $teamId, active: $active) {
+    edges {
+      node {
+        id
+        title
+        ownerId
+        cycle {
+          id
+          period
+          cadence
+          dateEnd
+        }
+        status {
+          progress
+          confidence
+        }
+        delta {
+          progress
+        }
+        policy {
+          update
+          delete
+        }
+      }
+    }
+  }
+}

--- a/src/components/User/ActiveObjectives/wrapper.tsx
+++ b/src/components/User/ActiveObjectives/wrapper.tsx
@@ -1,0 +1,116 @@
+import { useQuery } from '@apollo/client'
+import { Stack } from '@chakra-ui/react'
+import React, { useEffect, useState } from 'react'
+import { useRecoilState, useSetRecoilState } from 'recoil'
+
+import { OKRsEmptyState } from 'src/components/Objective/OKRsEmptyState/wrapper'
+import { OKRsSkeleton } from 'src/components/Objective/OKRsSkeleton/wrapper'
+import { Team } from 'src/components/Team/types'
+
+import { useConnectionEdges } from '../../../state/hooks/useConnectionEdges/hook'
+import { useCycleObjectives } from '../../../state/hooks/useCycleObjectives/hook'
+import { useRecoilFamilyLoader } from '../../../state/recoil/hooks'
+import { isReloadNecessary, objectiveAtomFamily } from '../../../state/recoil/objective'
+import { teamActiveObjectives } from '../../../state/recoil/team/active-objectives'
+import {
+  ObjectivesViewMode,
+  teamObjectivesViewMode,
+} from '../../../state/recoil/team/objectives-view-mode'
+import { CycleObjectives } from '../../Cycle/Objectives/wrapper'
+import { Objective } from '../../Objective/types'
+import { GraphQLConnectionPolicy, GraphQLEdge, GraphQLEffect } from '../../types'
+import { User } from '../types'
+
+import queries from './queries.gql'
+
+export interface TeamActiveObjectivesProperties {
+  teamID: Team['id']
+  userID: User['id']
+}
+
+export interface GetTeamActiveObjectivesQuery {
+  objectives: {
+    edges: Array<GraphQLEdge<Objective>>
+  }
+}
+
+export const ActiveObjectives = ({ teamID, userID }: TeamActiveObjectivesProperties) => {
+  const [objectivesPolicy, setObjectivesPolicy] = useState<GraphQLConnectionPolicy>()
+  const [activeObjectives, setActiveObjectives] = useRecoilState(teamActiveObjectives(teamID))
+  const [shouldUpdateObjectives, setShouldUpdateObjectives] = useRecoilState(isReloadNecessary)
+  const [hasNotActiveObjectives] = useState(false)
+  const setObjectivesViewMode = useSetRecoilState(teamObjectivesViewMode(teamID))
+  const [loadObjectivesOnRecoil] = useRecoilFamilyLoader<Objective>(objectiveAtomFamily)
+
+  const [objectiveEdges, setObjectiveEdges, _, isRemoteDataLoaded] = useConnectionEdges<Objective>()
+  const [cycles, setCycleObjectives, cycleObjectives, isLoaded] = useCycleObjectives()
+
+  const { called, refetch } = useQuery<GetTeamActiveObjectivesQuery>(queries.GET_OBJECTIVES, {
+    fetchPolicy: 'no-cache',
+    variables: {
+      teamId: teamID,
+      onwerId: userID,
+      active: true,
+    },
+    notifyOnNetworkStatusChange: true,
+    onCompleted: ({ objectives }) => {
+      setActiveObjectives(objectives?.edges ?? [])
+    },
+  })
+
+  const handleViewOldCycles = () => {
+    setObjectivesViewMode(ObjectivesViewMode.NOT_ACTIVE)
+  }
+
+  const handleRefetch = async () => {
+    void refetch({ teamID })
+  }
+
+  useEffect(() => {
+    if (called && activeObjectives) setObjectiveEdges(activeObjectives)
+  }, [called, activeObjectives, setObjectiveEdges])
+
+  useEffect(() => {
+    if (isRemoteDataLoaded) setCycleObjectives(objectiveEdges)
+  }, [objectiveEdges, setCycleObjectives, isRemoteDataLoaded])
+
+  useEffect(() => {
+    loadObjectivesOnRecoil(cycleObjectives)
+  }, [cycleObjectives, loadObjectivesOnRecoil])
+
+  useEffect(() => {
+    if (shouldUpdateObjectives) {
+      void refetch({ teamID })
+      setShouldUpdateObjectives(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldUpdateObjectives])
+
+  return (
+    <Stack spacing={12} h="full">
+      {isLoaded ? (
+        cycles.length === 0 ? (
+          <OKRsEmptyState
+            userID={userID}
+            teamID={teamID}
+            isAllowedToCreateObjectives={objectivesPolicy?.create === GraphQLEffect.ALLOW}
+            onViewOldCycles={hasNotActiveObjectives ? handleViewOldCycles : undefined}
+            onNewObjective={handleRefetch}
+          />
+        ) : (
+          cycles.map(([cycle, objectiveIDs]) => (
+            <CycleObjectives
+              key={cycle.id}
+              cycle={cycle}
+              objectiveIDs={objectiveIDs}
+              userID={userID}
+              teamID={teamID}
+            />
+          ))
+        )
+      ) : (
+        <OKRsSkeleton />
+      )}
+    </Stack>
+  )
+}

--- a/src/components/User/NotActiveObjectives/messages.ts
+++ b/src/components/User/NotActiveObjectives/messages.ts
@@ -1,0 +1,29 @@
+import { defineMessages } from 'react-intl'
+
+type TeamNotActiveObjectivesMessages =
+  | 'timeMachineTitle'
+  | 'timeMachineDescription'
+  | 'timeMachineCloseIconDesc'
+
+export default defineMessages<TeamNotActiveObjectivesMessages>({
+  timeMachineTitle: {
+    defaultMessage: 'Máquina do tempo',
+    id: 'Sm4xi7',
+    description:
+      "This message is displayed as the title of the time machine section in a team's page",
+  },
+
+  timeMachineDescription: {
+    defaultMessage: 'Explorar ciclos anteriores',
+    id: '5o6tYt',
+    description:
+      "This message appears below the time machine title, as an auxiliary title in a team's page",
+  },
+
+  timeMachineCloseIconDesc: {
+    defaultMessage: 'Um ícone de X. Ao clicar nele você irá fechar a máquina do tempo',
+    id: '81Bqza',
+    description:
+      "This message is used by screen readers to explain our time machine close button inside a team's page",
+  },
+})

--- a/src/components/User/NotActiveObjectives/time-machine-controller.tsx
+++ b/src/components/User/NotActiveObjectives/time-machine-controller.tsx
@@ -1,0 +1,56 @@
+import { Stack, Heading, IconButton } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import TimesIcon from '../../Icon/Times'
+
+import messages from './messages'
+
+interface TimeMachineControllerProperties {
+  onClose: () => void
+}
+
+export const TimeMachineController = ({ onClose }: TimeMachineControllerProperties) => {
+  const intl = useIntl()
+
+  return (
+    <Stack spacing={4}>
+      <Heading as="h2" fontSize="sm" color="gray.500" textTransform="uppercase">
+        {intl.formatMessage(messages.timeMachineTitle)}
+      </Heading>
+
+      <Stack
+        direction="row"
+        bg="white"
+        py={8}
+        px={6}
+        boxShadow="for-background.light"
+        borderRadius="10"
+        alignItems="center"
+        spacing={8}
+      >
+        <Heading as="h3" fontSize="lg" color="gray.500" fontWeight={500} flexGrow={1}>
+          {intl.formatMessage(messages.timeMachineDescription)}
+        </Heading>
+
+        <IconButton
+          aria-label={intl.formatMessage(messages.timeMachineCloseIconDesc)}
+          bg="gray.50"
+          borderRadius="full"
+          color="gray.300"
+          _hover={{
+            bg: 'red.500',
+            color: 'white',
+          }}
+          onClick={onClose}
+        >
+          <TimesIcon
+            desc={intl.formatMessage(messages.timeMachineCloseIconDesc)}
+            fill="currentColor"
+            stroke="currentColor"
+          />
+        </IconButton>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/components/User/NotActiveObjectives/wrapper.tsx
+++ b/src/components/User/NotActiveObjectives/wrapper.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from '@apollo/client'
+import { Stack } from '@chakra-ui/react'
+import React, { useEffect } from 'react'
+import { useSetRecoilState } from 'recoil'
+
+import { OKRsEmptyState } from 'src/components/Objective/OKRsEmptyState/wrapper'
+import { OKRsSkeleton } from 'src/components/Objective/OKRsSkeleton/wrapper'
+
+import { useConnectionEdges } from '../../../state/hooks/useConnectionEdges/hook'
+import { useCycleFilters } from '../../../state/hooks/useCycleFilters/hook'
+import { useCycleObjectives } from '../../../state/hooks/useCycleObjectives/hook'
+import { cycleAtomFamily } from '../../../state/recoil/cycle'
+import { useRecoilFamilyLoader } from '../../../state/recoil/hooks'
+import { objectiveAtomFamily } from '../../../state/recoil/objective'
+import {
+  ObjectivesViewMode,
+  teamObjectivesViewMode,
+} from '../../../state/recoil/team/objectives-view-mode'
+import { CycleObjectives } from '../../Cycle/Objectives/wrapper'
+import { Objective } from '../../Objective/types'
+import { GraphQLEdge } from '../../types'
+import queries from '../ActiveObjectives/queries.gql'
+
+import { TimeMachineController } from './time-machine-controller'
+
+interface TeamNotActiveObjectivesProperties {
+  teamID: string
+  userID: string
+}
+
+export interface GetTeamNotActiveObjectivesQuery {
+  objectives: {
+    edges: Array<GraphQLEdge<Objective>>
+  }
+}
+
+export const TeamNotActiveObjectives = ({ teamID, userID }: TeamNotActiveObjectivesProperties) => {
+  const setObjectivesViewMode = useSetRecoilState(teamObjectivesViewMode(teamID))
+  const [loadObjectivesOnRecoil] = useRecoilFamilyLoader<Objective>(objectiveAtomFamily)
+  const [loadCyclesOnRecoil] = useRecoilFamilyLoader<Objective>(cycleAtomFamily)
+
+  const [objectiveEdges, setObjectiveEdges, _, isConnectionLoaded] = useConnectionEdges<Objective>()
+  const [objectiveCycles, setCycleObjectives, cycleObjectives] = useCycleObjectives()
+
+  const [filteredCycles, __, { updateCycles, isLoaded, cycles }] = useCycleFilters(teamID)
+
+  const handleClose = () => {
+    setObjectivesViewMode(ObjectivesViewMode.ACTIVE)
+  }
+
+  const filteredCycleIDs = new Set(filteredCycles.map((cycle) => cycle.id))
+  const filteredObjectiveCycles = objectiveCycles.filter(([cycle]) =>
+    filteredCycleIDs.has(cycle.id),
+  )
+
+  useQuery<GetTeamNotActiveObjectivesQuery>(queries.GET_OBJECTIVES, {
+    variables: {
+      teamId: teamID,
+      ownerId: userID,
+      active: false,
+    },
+    onCompleted: (data) => {
+      setObjectiveEdges(data?.objectives?.edges ?? [])
+    },
+  })
+
+  useEffect(() => {
+    if (objectiveEdges) setCycleObjectives(objectiveEdges)
+  }, [objectiveEdges, setCycleObjectives])
+
+  useEffect(() => {
+    loadObjectivesOnRecoil(cycleObjectives)
+  }, [cycleObjectives, loadObjectivesOnRecoil])
+
+  useEffect(() => {
+    if (isConnectionLoaded) updateCycles(objectiveCycles.map(([cycle]) => cycle))
+  }, [objectiveCycles, isConnectionLoaded, updateCycles])
+
+  useEffect(() => {
+    loadCyclesOnRecoil(cycles)
+  }, [cycles, loadCyclesOnRecoil])
+
+  return (
+    <Stack spacing={12} h="full">
+      <TimeMachineController onClose={handleClose} />
+
+      {isLoaded ? (
+        filteredObjectiveCycles.length === 0 ? (
+          <OKRsEmptyState userID={userID} teamID={teamID} />
+        ) : (
+          filteredObjectiveCycles.map(([cycle, objectiveIDs]) => (
+            <CycleObjectives
+              key={cycle.id}
+              isDisabled
+              cycle={cycle}
+              objectiveIDs={objectiveIDs}
+              teamID={teamID}
+              userID={userID}
+            />
+          ))
+        )
+      ) : (
+        <OKRsSkeleton />
+      )}
+    </Stack>
+  )
+}

--- a/src/components/User/Objectives/wrapper.tsx
+++ b/src/components/User/Objectives/wrapper.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { ObjectivesViewMode } from 'src/state/recoil/team/objectives-view-mode'
+
+import { ActiveObjectives } from '../ActiveObjectives/wrapper'
+
+interface TeamObjectivesProperties {
+  teamID: string
+  userID: string
+  viewType: ObjectivesViewMode
+}
+
+export const UserObjectives = ({ teamID, userID, viewType }: TeamObjectivesProperties) => {
+  const ViewModeComponentHashmap = {
+    [ObjectivesViewMode.ACTIVE]: ActiveObjectives,
+    [ObjectivesViewMode.NOT_ACTIVE]: ActiveObjectives,
+  }
+  const View = ViewModeComponentHashmap[viewType]
+
+  return <View teamID={teamID} userID={userID} />
+}


### PR DESCRIPTION
Movi a estrutura principal do accordeon de Objetivos para o componente de Objetivo e deixei a parte relativa a time como estava. Usei uma estrutura parecida com a de time para usuários e apliquei como teste na página de minhas coisas (isso vai precisar ser desfeito). Acredito que vendo o código facilite o entendimento.

No backend, usar o branch `refactor/objective-resolver` com um merge de `feat/yearly-and-quarterly-user-progress`.