### PR TITLE
feat(amplitude/track-teamleader) track isTeamLeader flag on Amplitude

### DIFF
--- a/src/components/User/Me/me.tsx
+++ b/src/components/User/Me/me.tsx
@@ -29,6 +29,7 @@ export interface UserNamedAvatarDataQuery {
   email: string
   gender: USER_GENDER
   role: string
+  isTeamLeader: boolean
   createdAt: string
   companies: GraphQLConnection<Team>
   teams: GraphQLConnection<Team>

--- a/src/components/User/Me/queries.gql
+++ b/src/components/User/Me/queries.gql
@@ -7,6 +7,7 @@ query GET_USER_NAMED_AVATAR_DATA {
     email
     gender
     role
+    isTeamLeader
     createdAt
     yearlyProgress {
       showProgress

--- a/src/state/hooks/useAmplitude/marshal-amplitude-user.ts
+++ b/src/state/hooks/useAmplitude/marshal-amplitude-user.ts
@@ -18,6 +18,7 @@ export const marshalAmplitudeUser = (user: UserNamedAvatarDataQuery): AmplitudeU
   email: user.email,
   gender: user.gender,
   role: user.role,
+  isTeamLeader: user.isTeamLeader,
   createdAt: user.createdAt,
 })
 

--- a/src/state/hooks/useAmplitude/types.ts
+++ b/src/state/hooks/useAmplitude/types.ts
@@ -6,6 +6,7 @@ export type AmplitudeUser = {
   email: string
   gender: USER_GENDER
   role: string
+  isTeamLeader: boolean
   createdAt: string
 }
 


### PR DESCRIPTION
## 🎢 Motivation

Allow Amplitude to know if a user is a team leader.

## 🔧 Solution

Added the flag isTeamLeader in the query to get this information from the backend.

## 🚨  Testing

Use this extension: [`Amplitude Event Explorer`](https://chrome.google.com/webstore/detail/amplitude-event-explorer/acehfjhnmhbmgkedjmjlobpgdicnhkbp), and verify if the isTeamLeader tag is passed.

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-421`](https://getbud.atlassian.net/jira/software/projects/BUD22/boards/16?assignee=622f47431c09d2007012fa64&selectedIssue=BUD22-421)

## 🔗 Related PRs

- [`business#203`](https://github.com/budproj/business/pull/203)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
