### PR TITLE
fix(team/create): set current user as owner of a new team

### DIFF
--- a/src/components/Team/SaveTeamModal/save-team-modal.tsx
+++ b/src/components/Team/SaveTeamModal/save-team-modal.tsx
@@ -68,7 +68,7 @@ export const SaveTeamModal = ({ teamId, isOpen, onClose, isEditing }: SaveTeamMo
   const setShouldUpdateObjectives = useSetRecoilState(isReloadNecessary)
   const [childTeams, setChildTeamEdges] = useConnectionEdges<Team>()
 
-  const [owner, setOwner] = useState(currentUserID)
+  const [owner, setOwner] = useState('')
   const [parentTeam, setParentTeam] = useState<Partial<Team>>({})
   const [name, setName] = useState(isEditing ? team?.name : '')
   const [description, setDescription] = useState(isEditing ? team?.description : '')
@@ -85,11 +85,10 @@ export const SaveTeamModal = ({ teamId, isOpen, onClose, isEditing }: SaveTeamMo
         setParentTeam(team.parent)
       }
 
-      if (team?.ownerId && isEditing) {
-        setOwner(team.ownerId)
-      }
+      const ownerID = isEditing ? team?.ownerId ?? '' : currentUserID ?? ''
+      setOwner(ownerID)
     }
-  }, [team, setChildTeamEdges, isEditing])
+  }, [team, setChildTeamEdges, isEditing, currentUserID])
 
   const [saveOrUpdateTeam, { loading }] = useMutation<AddSubteamMutationResult>(
     isEditing ? queries.UPDATE_TEAM : queries.CREATE_TEAM,


### PR DESCRIPTION
## 🎢 Motivation

Fix the owner selector when on the create team modal

## 🔧 Solution

Set the current user as default owner when the modal is creation

## 🚨  Testing

Click on the create menu button and it should show the current user as owner

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [x] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
