### PR TITLE
fix(team-list): fixing bug that does not show the leader if the leade…

### DIFF
--- a/src/components/Page/Team/queries.gql
+++ b/src/components/Page/Team/queries.gql
@@ -12,7 +12,13 @@ query GET_TEAM_DATA($teamId: ID!) {
     }
     owner {
       id
+      firstName
+      nickname
       fullName
+      role
+      picture
+      about
+      linkedInProfileAddress
     }
     status {
       progress

--- a/src/components/User/SelectFromList/Content/users-in-context.tsx
+++ b/src/components/User/SelectFromList/Content/users-in-context.tsx
@@ -40,7 +40,7 @@ export const UsersInContext = ({
   const emptyState = <Text color="black.600">{intl.formatMessage(messages.emptySearchState)}</Text>
 
   useEffect(() => {
-    loadUsers(items)
+    loadUsers([...items, teamLeader])
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items])
 


### PR DESCRIPTION
…r is not from the team

## 🎢 Motivation

Fixing a bug that does not show the leader if the leader is not from the team

## 🔧 Solution

Inserting the leader in the loaded users context

## 🚨  Testing

Open a team page that the leader is not from the team and it should appear in the users team list.

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-451`](https://getbud.atlassian.net/jira/software/projects/BUD22/boards/16?assignee=6221193315521d00726b288c&selectedIssue=BUD22-451)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
