### PR TITLE
fix(cycle-date): parse date as utc timezone

### DIFF
--- a/src/components/Cycle/List/Body/Columns/DateEnd/date-end.tsx
+++ b/src/components/Cycle/List/Body/Columns/DateEnd/date-end.tsx
@@ -27,7 +27,7 @@ const CyclesListBodyColumnDateEnd = ({
     <CyclesListBodyColumnBase>
       <Flex gridGap={2} flexDir="column">
         <Skeleton isLoaded={isdateEndLoaded} {...buildSkeletonMinSize(isdateEndLoaded, 100, 28)}>
-          <Text>{intl.formatDate(dateEnd)}</Text>
+          <Text>{intl.formatDate(dateEnd, { timeZone: 'UTC' })}</Text>
         </Skeleton>
       </Flex>
     </CyclesListBodyColumnBase>

--- a/src/components/Cycle/List/Body/Columns/DateStart/date-start.tsx
+++ b/src/components/Cycle/List/Body/Columns/DateStart/date-start.tsx
@@ -31,7 +31,7 @@ const CyclesListBodyColumnDateStart = ({
           isLoaded={isdateStartLoaded}
           {...buildSkeletonMinSize(isdateStartLoaded, 100, 28)}
         >
-          <Text>{intl.formatDate(dateStart)}</Text>
+          <Text>{intl.formatDate(dateStart, { timeZone: 'UTC' })}</Text>
         </Skeleton>
       </Flex>
     </CyclesListBodyColumnBase>


### PR DESCRIPTION
## 🎢 Motivation

The dates for cycles on the listing table are presented as the day before

## 🔧 Solution

It considers the dates as UTC when displaying.

## 🚨  Testing

Go to the cycle page and the date on the table should be the same as the date on the modal.

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-479`](https://getbud.atlassian.net/browse/BUD22-479)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
