### PR TITLE
feat(routin/delete)

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -1083,6 +1083,10 @@
     "defaultMessage": "Know more",
     "description": "A link to a page that talks about the retrospective routine."
   },
+  "e/i9Ml": {
+    "defaultMessage": "A three-dot icon used on a button that opens a menu of options.",
+    "description": "Icon with three dots used on a button that opens an options menu."
+  },
   "e2FL3I": {
     "defaultMessage": "An icon of a plus sign. By clicking on it, you will add a new item to the check-list",
     "description": "This is used by screen readers to understand the insert new check mark icon in our key-result drawer"
@@ -1226,6 +1230,10 @@
   "fsAK9T": {
     "defaultMessage": "Select...",
     "description": "This message appears in the input when no user is selected."
+  },
+  "fSrztQ": {
+    "defaultMessage": "Share your priorities, achievements and barriers with your team. Track and interact with your peers on their journey. {link}",
+    "description": "Description of the content of the Retrospective tab on the teams page."
   },
   "fv5OeR": {
     "defaultMessage": "{confidence, select, roadblock {All key results with a {confidence}} other {All key results with {confidence}}}",
@@ -1751,6 +1759,10 @@
     "defaultMessage": "Are you sure that you want to do it? This action is irreversible",
     "description": "This text is used as a fallback to the confirmation modal title. It is displayed if the component did not received a custom message to display"
   },
+  "Jw9V43": {
+    "defaultMessage": "Options",
+    "description": "This message appears how description to menu action options"
+  },
   "jwsMer": {
     "defaultMessage": "Last check-in",
     "description": "the prefix that is displayed in the last update checkmark."
@@ -1998,6 +2010,10 @@
   "LvI+KK": {
     "defaultMessage": "Language",
     "description": "This message is the label of our locale switcher in the settings page"
+  },
+  "lvyLZA": {
+    "defaultMessage": "Delete this answer",
+    "description": "This message is used in the button where the user can delete a routine response."
   },
   "lWcm/y": {
     "defaultMessage": "There are no key results with this confidence level.",
@@ -2735,6 +2751,10 @@
     "defaultMessage": " \"x\" icon. By clicking on it you will close the progress box",
     "description": "This description is used for accessibility. Screen readers uses it when they hover the close icon button in our progress slider popover close button"
   },
+  "sX1k+9": {
+    "defaultMessage": "Answer deleted successfully!",
+    "description": "This message appears in a toast indicating success in deleting a routines response."
+  },
   "SxsVDt": {
     "defaultMessage": "Goal",
     "description": "This is the label of the check-in form that indicates the goal for her/his key result"
@@ -2883,6 +2903,10 @@
     "defaultMessage": "Team Ranking for {quarter}",
     "description": "Title to show on the team ranking page"
   },
+  "UHZQHg": {
+    "defaultMessage": "Answers",
+    "description": "This message appears in the subtitle of the menu that allows users to browse responses through the history."
+  },
   "ui441M": {
     "defaultMessage": "Rounded corners square icon with a pencil inside",
     "description": "The desc message for the EditSquare icon. This icon is used to ilustrate our key results"
@@ -2942,6 +2966,10 @@
   "UUo+Pt": {
     "defaultMessage": "This team is a company",
     "description": "The title message for the crown icon. This icon is used to ilustrate when a team card is actually a company"
+  },
+  "uxjg0W": {
+    "defaultMessage": "Could not delete answer!",
+    "description": "This message appears in a toast indicating that it was not possible to delete a routines response."
   },
   "uXQE/x": {
     "defaultMessage": "View, through the progress bars, the general progress of all companies areas, and related teams and sub-teams.",
@@ -3540,7 +3568,7 @@
     "description": "The desc message for the Graph icon. This icon is used to ilustrate our key results"
   },
   "texterify_timestamp": {
-    "defaultMessage": "2022-10-27T01:24:35Z",
+    "defaultMessage": "2022-11-07T18:21:09Z",
     "description": ""
   }
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -11,9 +11,21 @@
     "defaultMessage": "Clique para começar a digitar",
     "description": "This message appears as a placeholder in the input where the user types their response."
   },
-  "+6p/sC": {
-    "defaultMessage": "Clique aqui para comentar :)",
-    "description": "This text is displayed in our comment input in our key result drawer when it has no value"
+  "+G9goh": {
+    "defaultMessage": "Ver mais...",
+    "description": "This text is displayed in the button that expands a truncated text"
+  },
+  "+IK11v": {
+    "defaultMessage": "O desenho de um fantasma, ilustrando que você está em uma página que não existe",
+    "description": "This message is the alt message for our box drawing in the unknown error page"
+  },
+  "+O5SW4": {
+    "defaultMessage": "Um ícone com uma série de traços verticais. Clique e arraste ele para reordenar seus resultados chave",
+    "description": "The alternative text explaining our reorder icon"
+  },
+  "+XSqc3": {
+    "defaultMessage": "Última atualização",
+    "description": "This prefix is displayed as default in our last updated component"
   },
   "+ajAuo": {
     "defaultMessage": "Nenhuma pessoa encontrada",
@@ -23,18 +35,6 @@
     "defaultMessage": "Rotinas",
     "description": "The title of the first section of My Week notification tab."
   },
-  "+CyB1n": {
-    "defaultMessage": "Data Limite",
-    "description": "The heading text of the goal section in our key-result drawer"
-  },
-  "+G9goh": {
-    "defaultMessage": "Ver mais...",
-    "description": "This text is displayed in the button that expands a truncated text"
-  },
-  "+IK11v": {
-    "defaultMessage": "O desenho de um fantasma, ilustrando que você está em uma página que não existe",
-    "description": "This message is the alt message for our box drawing in the unknown error page"
-  },
   "+kQOSG": {
     "defaultMessage": "Procurar Times",
     "description": "The placeholder in explore page"
@@ -42,10 +42,6 @@
   "+o53JX": {
     "defaultMessage": "{quantityofmembers} membros adicionados ao time com sucesso.",
     "description": "This message appears in a successful toast when we add more than one user to a team."
-  },
-  "+O5SW4": {
-    "defaultMessage": "Um ícone com uma série de traços verticais. Clique e arraste ele para reordenar seus resultados chave",
-    "description": "The alternative text explaining our reorder icon"
   },
   "+r3NGz": {
     "defaultMessage": "Progresso",
@@ -55,21 +51,9 @@
     "defaultMessage": "Atualizar",
     "description": "This message is displayed in a tooltip above the SliderThumb on our sliders"
   },
-  "+XSqc3": {
-    "defaultMessage": "Última atualização",
-    "description": "This prefix is displayed as default in our last updated component"
-  },
-  "//f0UA": {
-    "defaultMessage": "Timeline | bud",
-    "description": "The page title that is displayed in the browser tab"
-  },
   "/2GFGI": {
     "defaultMessage": "O prazo deste objetivo",
     "description": "The title text of our calendar icon in our objective accordion, it is displayed when an user hover the icon itself"
-  },
-  "/50OpL": {
-    "defaultMessage": "Meta",
-    "description": "The heading text of the goal section in our key-result drawer"
   },
   "/6mxm9": {
     "defaultMessage": "Nome da empresa",
@@ -79,21 +63,9 @@
     "defaultMessage": "Status",
     "description": "This text is displayed in our check-in card, as a title for the right column in the progress increase section"
   },
-  "/aK0UI": {
-    "defaultMessage": "Um ícone de um avião de papel. Ao clicar nele você irá enviar um comentário",
-    "description": "The alternative text explaining our paper plane icon"
-  },
-  "/cw+5N": {
-    "defaultMessage": "Um botão que ao ser clicado direciona o usuário para a questão anterior no formulário de rotinas.",
-    "description": "This message is the description of a button icon that, when clicked, directs the user to the previous question in the routines form."
-  },
   "/Duwsm": {
     "defaultMessage": "Convidar usuário automaticamente",
     "description": "This is the label that defines if we should automatically invite the new user while creating a new workspace"
-  },
-  "/DyxUT": {
-    "defaultMessage": "Último check-in",
-    "description": "This message is displayed alongisde with the key-result name, as the prefix for our last update text component"
   },
   "/H4hHb": {
     "defaultMessage": "Buscar subtimes",
@@ -107,6 +79,18 @@
     "defaultMessage": "Uma seta em círculo, demonstrando que ao clicar aqui você redefinirá essa ação",
     "description": "This is the desc attribute of our reset icon. It is used by screen readers"
   },
+  "/VrdI0": {
+    "defaultMessage": "Um ícone de pasta",
+    "description": "The desc message for the Folder icon. This icon is used to ilustrate our key results"
+  },
+  "/aK0UI": {
+    "defaultMessage": "Um ícone de um avião de papel. Ao clicar nele você irá enviar um comentário",
+    "description": "The alternative text explaining our paper plane icon"
+  },
+  "/cw+5N": {
+    "defaultMessage": "Um botão que ao ser clicado direciona o usuário para a questão anterior no formulário de rotinas.",
+    "description": "This message is the description of a button icon that, when clicked, directs the user to the previous question in the routines form."
+  },
   "/uYO8t": {
     "defaultMessage": "Perfil",
     "description": "The page meta title"
@@ -114,10 +98,6 @@
   "/vJzGe": {
     "defaultMessage": "Um ícone de marcador de página",
     "description": "The desc message for the Bookmark icon. This icon is used to ilustrate our key results"
-  },
-  "/VrdI0": {
-    "defaultMessage": "Um ícone de pasta",
-    "description": "The desc message for the Folder icon. This icon is used to ilustrate our key results"
   },
   "/xx1Eb": {
     "defaultMessage": "Descrição",
@@ -139,29 +119,9 @@
     "defaultMessage": "Um ícone de bussúla",
     "description": "The desc message for the Discovery icon. This icon is used to ilustrate our key results"
   },
-  "0d1/rp": {
-    "defaultMessage": "Indica o quanto esse resultado-chave evoluiu até o momento",
-    "description": "This tooltip explains the fourth column of the key result list"
-  },
-  "0dk0bw": {
-    "defaultMessage": "O logotipo do LinkedIn. Ao clicar você irá visitar o perfil do LinkedIn deste usuário",
-    "description": "This message is displayed to screen readers to explain our LinkedIn icon"
-  },
   "0GnOhy": {
     "defaultMessage": "Criar novo ambiente",
     "description": "The page title that our users should see in this page"
-  },
-  "0J4rjt": {
-    "defaultMessage": "Cancelar",
-    "description": "This text is used as a fallback to the confirmation modal cancel button. It is displayed if the component did not received a custom button label"
-  },
-  "0kb3ea": {
-    "defaultMessage": "Criar um subtime",
-    "description": "This text appears inside the create subteam empty state, a button to create subteams"
-  },
-  "0kNbEF": {
-    "defaultMessage": "Você desativou {name} com sucesso",
-    "description": "This message is used as a toast message when we finish deactivating a given user"
   },
   "0N9lO8": {
     "defaultMessage": "Central de ajuda",
@@ -187,6 +147,22 @@
     "defaultMessage": "Novo valor",
     "description": "This is the label of the check-in form that indicates to which value the user would update her/his key result"
   },
+  "0d1/rp": {
+    "defaultMessage": "Indica o quanto esse resultado-chave evoluiu até o momento",
+    "description": "This tooltip explains the fourth column of the key result list"
+  },
+  "0dk0bw": {
+    "defaultMessage": "O logotipo do LinkedIn. Ao clicar você irá visitar o perfil do LinkedIn deste usuário",
+    "description": "This message is displayed to screen readers to explain our LinkedIn icon"
+  },
+  "0kNbEF": {
+    "defaultMessage": "Você desativou {name} com sucesso",
+    "description": "This message is used as a toast message when we finish deactivating a given user"
+  },
+  "0kb3ea": {
+    "defaultMessage": "Criar um subtime",
+    "description": "This text appears inside the create subteam empty state, a button to create subteams"
+  },
   "0t238C": {
     "defaultMessage": "Formato do Resultado-chave",
     "description": "This label appears above the third input in our insert key-result drawer"
@@ -199,10 +175,6 @@
     "defaultMessage": "Valor Inicial",
     "description": "This text is used as a label on the update goal form inside the key-result drawers. That is the first label of that form"
   },
-  "1bgaUB": {
-    "defaultMessage": "Meta",
-    "description": "This text is used as a label on the update goal form inside the key-result drawers. That is the second label of that form"
-  },
   "1C5Zpe": {
     "defaultMessage": "Adicionar nova tarefa",
     "description": "This label appears in our key-result sidebar drawer, in the end of our checklist"
@@ -211,13 +183,17 @@
     "defaultMessage": "Na última hora",
     "description": "This label is displayed if the date difference is less than 1 hour"
   },
-  "1HBRw6": {
-    "defaultMessage": "Nenhuma atualização recente",
-    "description": "This label is displayed if we do not have any update date to display"
-  },
   "1IAVGz": {
     "defaultMessage": "Tarefas pendentes",
     "description": "Label for pending tasks selector item"
+  },
+  "1Ve0Ag": {
+    "defaultMessage": "Um ícone de um calendário, indicando que essa é a data limite do seu resultado-chave",
+    "description": "The description text for the key-result section goal icon"
+  },
+  "1bgaUB": {
+    "defaultMessage": "Meta",
+    "description": "This text is used as a label on the update goal form inside the key-result drawers. That is the second label of that form"
   },
   "1lccXL": {
     "defaultMessage": "Essa pergunta é obrigatória!",
@@ -231,10 +207,6 @@
     "defaultMessage": "Um ícone de mensagem",
     "description": "The desc message for the Message icon. This icon is used to ilustrate our key results"
   },
-  "1Ve0Ag": {
-    "defaultMessage": "Um ícone de um calendário, indicando que essa é a data limite do seu resultado-chave",
-    "description": "The description text for the key-result section goal icon"
-  },
   "2+RDgf": {
     "defaultMessage": "Adicionar Pessoa",
     "description": "The label text for the add button in our support team popover"
@@ -243,33 +215,9 @@
     "defaultMessage": "Mas não se preocupe, ela vai ficar bem! Enquanto trabalhamos nisso, você pode clicar no botão aqui embaixo para voltar para o painel :)",
     "description": "The description displayed in our unknown error page"
   },
-  "2ao/tW": {
-    "defaultMessage": "Sobrenome do usuário inicial",
-    "description": "The user last name while creating a new workspace"
-  },
-  "2chQA0": {
-    "defaultMessage": "Faz tempo que ninguém interage nesse resultado-chave. Que tal compartilhar uma informação relevante com o time? :)",
-    "description": "This text gives more details regarding our empty state card in the key result drawers"
-  },
   "2IBj4Z": {
     "defaultMessage": "Agora há pouco",
     "description": "This label is displayed if the date difference is less than 1 minute"
-  },
-  "2iSLX9": {
-    "defaultMessage": "Inglês",
-    "description": "This message is used as the label for the english language in our locale switcher"
-  },
-  "2leAvr": {
-    "defaultMessage": "Minhas Tarefas",
-    "description": "The header in my tasks title, inside my things page"
-  },
-  "2lGnmq": {
-    "defaultMessage": "Minha conta | bud",
-    "description": "The page title that is displayed in the browser tab for the my profile page"
-  },
-  "2nlZ3v": {
-    "defaultMessage": "Visualize e altere as configurações de sua conta.",
-    "description": "The page description that is displayed in Google and screen readers for the settings page."
   },
   "2QbXJB": {
     "defaultMessage": "Desculpe, aconteceu um erro inesperado. Tente novamente mais tarde",
@@ -282,6 +230,26 @@
   "2Vtwxl": {
     "defaultMessage": "Histórico de respostas",
     "description": "This message appears as the title of the card that lists the history of retrospectives answered by a user."
+  },
+  "2ao/tW": {
+    "defaultMessage": "Sobrenome do usuário inicial",
+    "description": "The user last name while creating a new workspace"
+  },
+  "2chQA0": {
+    "defaultMessage": "Faz tempo que ninguém interage nesse resultado-chave. Que tal compartilhar uma informação relevante com o time? :)",
+    "description": "This text gives more details regarding our empty state card in the key result drawers"
+  },
+  "2iSLX9": {
+    "defaultMessage": "Inglês",
+    "description": "This message is used as the label for the english language in our locale switcher"
+  },
+  "2leAvr": {
+    "defaultMessage": "Minhas Tarefas",
+    "description": "The header in my tasks title, inside my things page"
+  },
+  "2nlZ3v": {
+    "defaultMessage": "Visualize e altere as configurações de sua conta.",
+    "description": "The page description that is displayed in Google and screen readers for the settings page."
   },
   "30/f+o": {
     "defaultMessage": "Tem certeza que deseja desativar {gender, select, MALE {o} FEMALE {a} other {o}} usuári{gender, select, MALE {o} FEMALE {a} other {o}} {name}?",
@@ -298,6 +266,10 @@
   "39q6ig": {
     "defaultMessage": "OKRs",
     "description": "This message is displayed above the empty state inside the active cycles section at the Team page"
+  },
+  "3XEc2H": {
+    "defaultMessage": "Gênero do usuário inicial",
+    "description": "The user gender while creating a new workspace"
   },
   "3cM4+o": {
     "defaultMessage": "Pronto!",
@@ -331,10 +303,6 @@
     "defaultMessage": "Confira como seu card aparecerá para outros usuários.",
     "description": "This subtitle is displayed as the subtitle of the user card preview section in our user account settings page"
   },
-  "3XEc2H": {
-    "defaultMessage": "Gênero do usuário inicial",
-    "description": "The user gender while creating a new workspace"
-  },
   "3xZZCI": {
     "defaultMessage": "Esperado: {progress}%",
     "description": "Message to show the expetected progress of the project"
@@ -351,6 +319,18 @@
     "defaultMessage": "{team} | bud",
     "description": "The page title that is displayed in the browser tab"
   },
+  "4MCOg+": {
+    "defaultMessage": "Progresso Anual",
+    "description": "User's yearly progress title"
+  },
+  "4N1d+U": {
+    "defaultMessage": "Últimas atividades",
+    "description": "This text is displayed at the top of our timeline, as its title"
+  },
+  "4XHRhd": {
+    "defaultMessage": "Meta",
+    "description": "The heading text of the goal section in our key-result drawers"
+  },
   "4cmOYV": {
     "defaultMessage": "Painel",
     "description": "MainAppBar menu item that links to \"Dashboard\" page"
@@ -363,14 +343,6 @@
     "defaultMessage": "Empresa",
     "description": "This title is displayed as the heading of the definitions menu section"
   },
-  "4MCOg+": {
-    "defaultMessage": "Progresso Anual",
-    "description": "User's yearly progress title"
-  },
-  "4N1d+U": {
-    "defaultMessage": "Últimas atividades",
-    "description": "This text is displayed at the top of our timeline, as its title"
-  },
   "4npgR9": {
     "defaultMessage": "Usuári{gender, select, MALE {o} FEMALE {a} other {o}} criad{gender, select, MALE {o} FEMALE {a} other {o}} com sucesso",
     "description": "This message appears when we create a new user as a toast"
@@ -379,13 +351,17 @@
     "defaultMessage": "Clima dos Times {companypreposition} {company}",
     "description": "Title of the metrics card"
   },
-  "4XHRhd": {
-    "defaultMessage": "Meta",
-    "description": "The heading text of the goal section in our key-result drawers"
-  },
   "59sgdb": {
     "defaultMessage": "custom emoji with happy expression",
     "description": "This message is used as a description of emoji feeling 4"
+  },
+  "5Vuq/6": {
+    "defaultMessage": "{title} Sua resposta foi registrada e já está disponível para visualização nos times dos quais você faz parte. Para a página de qual deles você deseja ir?",
+    "description": "This text appears on the team redirection page after the user responds to the routines form"
+  },
+  "5XBq+p": {
+    "defaultMessage": "Meus Resultados-Chave | bud",
+    "description": "The page title that is displayed in the browser tab"
   },
   "5fB6ei": {
     "defaultMessage": "Desculpe, mas um erro inesperado aconteceu. Tente novamente mais tarde",
@@ -411,14 +387,6 @@
     "defaultMessage": "Essas são as pessoas ajudando {name} neste resultado-chave",
     "description": "The message to guide and describe on what is a support team"
   },
-  "5Vuq/6": {
-    "defaultMessage": "{title} Sua resposta foi registrada e já está disponível para visualização nos times dos quais você faz parte. Para a página de qual deles você deseja ir?",
-    "description": "This text appears on the team redirection page after the user responds to the routines form"
-  },
-  "5XBq+p": {
-    "defaultMessage": "Meus Resultados-Chave | bud",
-    "description": "The page title that is displayed in the browser tab"
-  },
   "5yQyMg": {
     "defaultMessage": "Explorar",
     "description": "The page title that our users should see in the teams explore page"
@@ -435,29 +403,13 @@
     "defaultMessage": "Ver detalhes",
     "description": "This message is the description of the option to view details  of a user."
   },
-  "66spXk": {
-    "defaultMessage": "Ver mais",
-    "description": "This message appears on button that loading more notifications in list."
-  },
   "68qL+a": {
     "defaultMessage": "Gênero da empresa",
     "description": "The label of the company gender while creating a new workspace"
   },
-  "6aChVs": {
-    "defaultMessage": "Nesta semana",
-    "description": "This label is displayed if the date difference is 1 week or less"
-  },
-  "6BeRhq": {
-    "defaultMessage": "Excluir este OKR",
-    "description": "This is the third option that appears when you open the menu of a given objective inside the accordion button"
-  },
   "6E9X3c": {
     "defaultMessage": "Redefinir",
     "description": "This is the button label that is displayed in our reset button"
-  },
-  "6gyBBo": {
-    "defaultMessage": "Sentimento",
-    "description": "This message appears on feeling chart tooltip as the title that suggests what the data means."
   },
   "6J+ZAo": {
     "defaultMessage": "Título",
@@ -471,13 +423,25 @@
     "defaultMessage": "Um círculo com um ponto de interrogação no meio",
     "description": "This message explains our tooltip icon for screen readers"
   },
-  "6spUEn": {
-    "defaultMessage": "Fazer check-in",
-    "description": "This message is displayed as a label button when the check-in form is closed in our key result section"
-  },
   "6Syzud": {
     "defaultMessage": "Novo objetivo",
     "description": "This message is used as the draft title of a new objective when an objective is created inside the team page"
+  },
+  "6XgcX8": {
+    "defaultMessage": "O time de apoio também pode fazer check-in nos resultados-chave dos quais participam.",
+    "description": "The tooltip text for the check-ins description"
+  },
+  "6aChVs": {
+    "defaultMessage": "Nesta semana",
+    "description": "This label is displayed if the date difference is 1 week or less"
+  },
+  "6gyBBo": {
+    "defaultMessage": "Sentimento",
+    "description": "This message appears on feeling chart tooltip as the title that suggests what the data means."
+  },
+  "6spUEn": {
+    "defaultMessage": "Fazer check-in",
+    "description": "This message is displayed as a label button when the check-in form is closed in our key result section"
   },
   "6uAE86": {
     "defaultMessage": "Criar Resultado-chave",
@@ -486,10 +450,6 @@
   "6vXlkc": {
     "defaultMessage": "Visualize os dados de avanço da empresa como um todo, suas prioridades, um gráfico de expectativa de avanço e o nível de confiança geral.",
     "description": "The page description that is displayed in Google and screen readers"
-  },
-  "6XgcX8": {
-    "defaultMessage": "O time de apoio também pode fazer check-in nos resultados-chave dos quais participam.",
-    "description": "The tooltip text for the check-ins description"
   },
   "728+oa": {
     "defaultMessage": "Todas as tarefas",
@@ -507,25 +467,9 @@
     "defaultMessage": "As notificações relacionadas a este resultado-chave, como novos comentários, também serão enviadas ao time de apoio.",
     "description": "The tooltip text for the notifications description"
   },
-  "7d+540": {
-    "defaultMessage": "Uma seta para cima, indicando que o menu de seleção de ciclos está aberto",
-    "description": "This message is displayed to the user screen reader when the year select menu is opened"
-  },
-  "7fTFkO": {
-    "defaultMessage": "Média do progresso de todos os seus resultados-chave no ciclo anual atual",
-    "description": "Yearly progress chart tooltip message"
-  },
   "7GDhfH": {
     "defaultMessage": "O ciclo está ativo, a funcionalidade de check-in está disponível, e o progresso está sendo mensurado.",
     "description": "This string is used to describe the cycles active status option."
-  },
-  "7tvIOz": {
-    "defaultMessage": "Adicionar resultado-chave",
-    "description": "This is the first option that appears when you open the menu of a given objective inside the accordion button"
-  },
-  "7uQQbf": {
-    "defaultMessage": "Nome do período anual",
-    "description": "The label of the company yearly period while creating a new workspace"
   },
   "7VhC49": {
     "defaultMessage": "Visão geral dos OKRs",
@@ -535,13 +479,21 @@
     "defaultMessage": "Um ícone de um alvo, que aparece junto com a pergunta de quais os focos do usuário para próxima semana.",
     "description": "This message appears as the title of the card that lists the history of retrospectives answered by a user."
   },
-  "7xrfSX": {
-    "defaultMessage": "Com barreira",
-    "description": "Title of barrier health strategy"
-  },
   "7Yw26b": {
     "defaultMessage": "Selecione o ano",
     "description": "This message is displayed when no year filter was selected"
+  },
+  "7d+540": {
+    "defaultMessage": "Uma seta para cima, indicando que o menu de seleção de ciclos está aberto",
+    "description": "This message is displayed to the user screen reader when the year select menu is opened"
+  },
+  "7uQQbf": {
+    "defaultMessage": "Nome do período anual",
+    "description": "The label of the company yearly period while creating a new workspace"
+  },
+  "7xrfSX": {
+    "defaultMessage": "Com barreira",
+    "description": "Title of barrier health strategy"
   },
   "8+y0VC": {
     "defaultMessage": "Nenhuma pessoa",
@@ -579,29 +531,13 @@
     "defaultMessage": "Cancelar",
     "description": "This message is used in the cancel button when we are in the confirmation dialog"
   },
-  "8EABR0": {
-    "defaultMessage": "Sobre você",
-    "description": "This is the label that goes on our user account settings page, at the seventh field to update the user informations"
-  },
   "8EZRzi": {
     "defaultMessage": "Dia de início do período trimestral",
     "description": "The label of the company quarterly date start while creating a new workspace"
   },
-  "8gbub2": {
-    "defaultMessage": "Status",
-    "description": "This message is displayed as the column header for the cycle table in the status column"
-  },
   "8HUHbX": {
     "defaultMessage": "atribuiu uma tarefa a você:",
     "description": "This message appears as describe on notification where a user is assigned to a task."
-  },
-  "8kcr+g": {
-    "defaultMessage": "Usuário",
-    "description": "This message is displayed as the user name whenever the user is not defined"
-  },
-  "8l7xtl": {
-    "defaultMessage": "Sair",
-    "description": "The label displayed in the user logout button"
   },
   "8LTdv4": {
     "defaultMessage": "Objetivo",
@@ -610,6 +546,18 @@
   "8YI1Fn": {
     "defaultMessage": "Financeiro (Real)",
     "description": "This message is displayed inside our key-result format select as the title of the coin BRL format"
+  },
+  "8gbub2": {
+    "defaultMessage": "Status",
+    "description": "This message is displayed as the column header for the cycle table in the status column"
+  },
+  "8kcr+g": {
+    "defaultMessage": "Usuário",
+    "description": "This message is displayed as the user name whenever the user is not defined"
+  },
+  "8l7xtl": {
+    "defaultMessage": "Sair",
+    "description": "The label displayed in the user logout button"
   },
   "91fiAW": {
     "defaultMessage": "Ícone de sino vermelho",
@@ -627,26 +575,6 @@
     "defaultMessage": "Um ícone de um lápix, que aparece junto com a pergunta de algum recado que o usuário deixou para o time",
     "description": "The alternative text explaining our graphic icon"
   },
-  "9dXuLd": {
-    "defaultMessage": "R$ 100",
-    "description": "This message is displayed inside our key-result format select as the example of the coin BRL format"
-  },
-  "9eQWJv": {
-    "defaultMessage": "Email do usuário inicial",
-    "description": "The user email while creating a new workspace"
-  },
-  "9GdiHI": {
-    "defaultMessage": "{name} perderá o acesso ao Bud e será removido dos times aos quais pertence, mas manteremos o histórico de check-ins e comentários feitos até aqui.",
-    "description": "This message appears in the confirmation dialog when we try to deactivate an user"
-  },
-  "9iN0R8": {
-    "defaultMessage": "Atenção! Essa ação não pode ser desfeita",
-    "description": "This message is used as the default message in our dangerous action confirmation modal"
-  },
-  "9lxU9H": {
-    "defaultMessage": "Escreva {keyword} para confirmar a exclusão",
-    "description": "This message appears as a placeholder on the input in the danger confirmation modal while deleting a given resource"
-  },
   "9O5Xaa": {
     "defaultMessage": "Seu time ainda não tem nenhum resultado-chave anual",
     "description": "Message to show when there are no summary results"
@@ -655,13 +583,25 @@
     "defaultMessage": "Data de fim",
     "description": "The company quarterly date end input placeholder while creating a new workspace"
   },
-  "9sw0lJ": {
-    "defaultMessage": "Selecione seu gênero",
-    "description": "This is the fallback value that goes on our user account settings page, at the sixth field to update the user informations. The fallback value appears if the user has no data at that field"
-  },
   "9Y9dS0": {
     "defaultMessage": "Nome do ciclo",
     "description": "The description for name cycle field"
+  },
+  "9dXuLd": {
+    "defaultMessage": "R$ 100",
+    "description": "This message is displayed inside our key-result format select as the example of the coin BRL format"
+  },
+  "9eQWJv": {
+    "defaultMessage": "Email do usuário inicial",
+    "description": "The user email while creating a new workspace"
+  },
+  "9iN0R8": {
+    "defaultMessage": "Atenção! Essa ação não pode ser desfeita",
+    "description": "This message is used as the default message in our dangerous action confirmation modal"
+  },
+  "9sw0lJ": {
+    "defaultMessage": "Selecione seu gênero",
+    "description": "This is the fallback value that goes on our user account settings page, at the sixth field to update the user informations. The fallback value appears if the user has no data at that field"
   },
   "A+zcmM": {
     "defaultMessage": "Selecionar",
@@ -679,69 +619,17 @@
     "defaultMessage": "Salvar",
     "description": "This text appears as a browser tooltip above the icon. This icon appears below an EditableTextArea. It is used to save the edition of that field"
   },
-  "a7sp2+": {
-    "defaultMessage": "Sim",
-    "description": "This message appears as a description of the first option."
-  },
-  "a8O2l+": {
-    "defaultMessage": "Um ícone com o sinal de \"mais\". Ao clicar aqui você irá abrir o menu para inserir um novo usuário",
-    "description": "This message is used in our new user button while seeing the user list"
-  },
-  "AbWup6": {
-    "defaultMessage": "{name} perderá o acesso ao Bud e será removido dos times aos quais pertence, mas manteremos o histórico de check-ins e comentários feitos por ele até aqui.",
-    "description": "This message appears in the confirmation dialog when we try to deactivate an user"
-  },
-  "acrz2t": {
-    "defaultMessage": "Cancelar",
-    "description": "The label of the cancel button of the create user form"
-  },
   "ADoBmy": {
     "defaultMessage": "Ícone de maleta representando o índice de produtividade",
     "description": "The description of the productivty icon"
-  },
-  "Afdu+X": {
-    "defaultMessage": "Excluir {type}",
-    "description": "This message appears as a button label on the delete confirmation button"
   },
   "AFjRlx": {
     "defaultMessage": "sem resposta",
     "description": "The text that appears in the user list, if the user hasn't answered yet"
   },
-  "agEavf": {
-    "defaultMessage": "Comente o que {user} compartilhou!",
-    "description": "This message appears as placeholder of input."
-  },
-  "agW42K": {
-    "defaultMessage": "Comece com um verbo de ação (atingir, alcançar, conquistar...) Torne mensurável definindo um número como indicador de sucesso Defina um desafio agressivo porém realista",
-    "description": "The description of the tip when you are creating a KR."
-  },
-  "ah2n1K": {
-    "defaultMessage": "Nome do período trimestral",
-    "description": "The label of the company quarterly period while creating a new workspace"
-  },
-  "aIGly+": {
-    "defaultMessage": "Gênero",
-    "description": "The company gender input placeholder while creating a new workspace"
-  },
   "AII0ao": {
     "defaultMessage": "Visualize seus resultados-chave e seus detalhes, atualize seu progresso e seu nível de confiança.",
     "description": "The page description that is displayed in Google and screen readers"
-  },
-  "aiRCwP": {
-    "defaultMessage": "Início",
-    "description": "The label text inside the Cycle section, above the start date in our key result single page or drawer"
-  },
-  "aKyktL": {
-    "defaultMessage": "Q2",
-    "description": "This button appears as an empty state while the user is selecting the cycle filter"
-  },
-  "AngG7m": {
-    "defaultMessage": "{today, select, true {hoje às} false {às} other {às}}",
-    "description": "The prefix of the hour description"
-  },
-  "aO+w74": {
-    "defaultMessage": "A confiança mudou neste check-in:",
-    "description": "This text is the first line of our icon tooltip when the check-in has a different confidence from the previous check-in"
   },
   "AO/RyT": {
     "defaultMessage": "Copiar título deste Resultado-Chave",
@@ -751,25 +639,13 @@
     "defaultMessage": "Você reativou {name} com sucesso.",
     "description": "This message appears in a toast after reactivating a user."
   },
-  "aT1RWB": {
-    "defaultMessage": "Confirme sua ação",
-    "description": "This message is displayed as the input label for the danger delete resource dialog"
-  },
   "ATbiBE": {
     "defaultMessage": "comentou no seu resultado-chave:",
     "description": "This message is displayed to describe a notification that occurs when someone comments on a user`s KR."
   },
-  "atQu7S": {
-    "defaultMessage": "Membro adicionado ao time com sucesso.",
-    "description": "This message appears on a successful toast when we add a user to a team."
-  },
-  "aVLR+w": {
-    "defaultMessage": "100%",
-    "description": "This message is displayed inside our key-result format select as the example of the percent format"
-  },
-  "az3ncM": {
-    "defaultMessage": "Atenção!{breakline}Esta ação não pode ser desfeita.",
-    "description": "This message is used as the title in our second dialog while removing a cycle"
+  "AngG7m": {
+    "defaultMessage": "{today, select, true {hoje às} false {às} other {às}}",
+    "description": "The prefix of the hour description"
   },
   "B/fme2": {
     "defaultMessage": "Que bom te ver de novo, {name}! :)",
@@ -795,53 +671,13 @@
     "defaultMessage": "Editar título do Objetivo",
     "description": "This is the second option that appears when you open the menu of a given objective inside the accordion button"
   },
-  "Ba8bU1": {
-    "defaultMessage": "Enviar comentário",
-    "description": "This label is displayed in the submit button in our drawer"
-  },
-  "bdkUKs": {
-    "defaultMessage": "Times",
-    "description": "This is the label that goes on our user account settings page, at the fourth field to update the user informations"
-  },
-  "bdYpnS": {
-    "defaultMessage": "CANCELAR",
-    "description": "This button is used to close the modal to add team members."
-  },
-  "BeFobb": {
-    "defaultMessage": "Isso também excluirá todos os OKRs criados neste ciclo. Essa ação não pode ser desfeita.",
-    "description": "This message is used as the description in our first dialog while removing a cycle"
-  },
   "BEo9Xi": {
     "defaultMessage": "Desativar usuári{gender, select, MALE {o} FEMALE {a} other {o}}",
     "description": "This text is used in our deactivate user button in the profile sidebar in our team page"
   },
-  "bgdTCS": {
-    "defaultMessage": "Planejamento Individual",
-    "description": "Individual OKR title on the navigation tab"
-  },
-  "bh8jgN": {
-    "defaultMessage": "novo!",
-    "description": "The text inside the tag to inform new buttons"
-  },
-  "biDODR": {
-    "defaultMessage": "Um ícone de lupa, indicando que este é um campo de busca",
-    "description": "This text is used by screen readers to explain the search icon in all our search inputs"
-  },
-  "BipZgy": {
-    "defaultMessage": "Desculpe, mas aconteceu um erro inesperado. Tente novamente mais tarde",
-    "description": "This text is displayed as a toast when the user tries to update an objective but an error occur"
-  },
   "BOJlqi": {
     "defaultMessage": "Progresso Trimestral",
     "description": "User's quarterly progress title"
-  },
-  "bPInC0": {
-    "defaultMessage": "Editar ciclo",
-    "description": "This message is the description of the edit cycle option."
-  },
-  "bqCVp4": {
-    "defaultMessage": "Clique aqui para começar a escrever um comentário",
-    "description": "This is the title text that is displayed if the user hovers the mouse in it"
   },
   "BROY+x": {
     "defaultMessage": "Progresso geral dos objetivos no ciclo trimestral atual",
@@ -851,41 +687,25 @@
     "defaultMessage": "São ousados, desafiadores e devem gerar um certo nível de desconforto por não serem fáceis de alcançar.",
     "description": "This card guides the creation of Objectives."
   },
-  "BydeYi": {
-    "defaultMessage": "Início",
-    "description": "The label text inside the Cycle section, above the start date in our key result single page or drawers"
-  },
   "BYO0eO": {
     "defaultMessage": "Um ícone de lixeira. Ao clicar nele você irá remover este resultado-chave",
     "description": "This text is used by screen readers to explain our trash can icon, used to remove that line in the key-result table"
   },
-  "bZXWCR": {
-    "defaultMessage": "Padrão",
-    "description": "This string is used to select the user default role."
+  "BeFobb": {
+    "defaultMessage": "Isso também excluirá todos os OKRs criados neste ciclo. Essa ação não pode ser desfeita.",
+    "description": "This message is used as the description in our first dialog while removing a cycle"
   },
-  "bZYEAl": {
-    "defaultMessage": "Um círculo com um sinal de subtração no meio, indicando que o progresso se manteve o mesmo",
-    "description": "This desc message explains the neutral icon for screen readers"
+  "BipZgy": {
+    "defaultMessage": "Desculpe, mas aconteceu um erro inesperado. Tente novamente mais tarde",
+    "description": "This text is displayed as a toast when the user tries to update an objective but an error occur"
+  },
+  "BydeYi": {
+    "defaultMessage": "Início",
+    "description": "The label text inside the Cycle section, above the start date in our key result single page or drawers"
   },
   "C6YmFo": {
     "defaultMessage": "Dicas para escrever um bom resultado-chave:",
     "description": "The title of the tip when you are creating a KR."
-  },
-  "c6ySN2": {
-    "defaultMessage": "Excluir este Objetivo e seus KRs",
-    "description": "This is the third option that appears when you open the menu of a given objective inside the accordion button"
-  },
-  "c8KQhI": {
-    "defaultMessage": "Semana de",
-    "description": "The prefix that appears in our chart tooltip in the key-result sidebar while seeing a quarterly key-result"
-  },
-  "c8UE59": {
-    "defaultMessage": "Um ícone de busca",
-    "description": "The desc message for the Search icon. This icon is used to ilustrate our key results"
-  },
-  "c8x6gV": {
-    "defaultMessage": "Explorar ciclos anteriores",
-    "description": "This message is displayed when the user opens the menu inside a given cycle at the team page"
   },
   "CDO5jp": {
     "defaultMessage": "Inativo",
@@ -895,17 +715,25 @@
     "defaultMessage": "Informações pessoais",
     "description": "This label defines the text on the first menu section option"
   },
-  "cGFQsk": {
-    "defaultMessage": "Desculpe, aconteceu um erro inesperado. Tente novamente mais tarde",
-    "description": "This message appears as an error toast when we have an unknown error while creating a new cycle"
+  "CMMxiV": {
+    "defaultMessage": "Enviar comentário",
+    "description": "The title displayed in the tooltip when the user hovers our paper plane icon in our add comment form"
   },
-  "chwy/J": {
-    "defaultMessage": "Responder hoje",
-    "description": "The text that goes in the update text, below the routine title, when the routine is up to date."
+  "CQAFfW": {
+    "defaultMessage": "Se tudo continuar assim, esperamos alcançar o resultado",
+    "description": "This text explains our tag to the user"
   },
-  "ciNUJf": {
-    "defaultMessage": "Explorar",
-    "description": "MainAppBar menu item that links to teams \"Explore\" page"
+  "CQPpEV": {
+    "defaultMessage": "Ativo",
+    "description": "This string is used to select the active cycles option."
+  },
+  "CS3a8I": {
+    "defaultMessage": "Ativo",
+    "description": "This option makes an active cycle"
+  },
+  "CWzl6a": {
+    "defaultMessage": "Nenhuma informação",
+    "description": "The fallback value appears if no value is defined for that text area. This text area is customizable, so it will only appears if no value is defined, and no custom fallback value was provided"
   },
   "CkCxOl": {
     "defaultMessage": "Posição do time",
@@ -919,73 +747,21 @@
     "defaultMessage": "Um ícone de busca. Ao clicar nele uma barra de busca se abrirá para você",
     "description": "The alternative text explaining our search icon"
   },
-  "CMMxiV": {
-    "defaultMessage": "Enviar comentário",
-    "description": "The title displayed in the tooltip when the user hovers our paper plane icon in our add comment form"
-  },
-  "CmpXX/": {
-    "defaultMessage": "OKRs da {company}",
-    "description": "Company OKR title on the navigation tab"
-  },
   "CmYkJk": {
     "defaultMessage": "Produtividade",
     "description": "The title of the productivity chart"
-  },
-  "cPGOoL": {
-    "defaultMessage": "Fale com nosso suporte técnico",
-    "description": "MainAppBar user menu third item option"
-  },
-  "CQAFfW": {
-    "defaultMessage": "Se tudo continuar assim, esperamos alcançar o resultado",
-    "description": "This text explains our tag to the user"
-  },
-  "CQiLwO": {
-    "defaultMessage": "Timeline",
-    "description": "MainAppBar menu item that links to teams \"Timeline\" page"
-  },
-  "CQPpEV": {
-    "defaultMessage": "Ativo",
-    "description": "This string is used to select the active cycles option."
   },
   "Cr1hEp": {
     "defaultMessage": "Check-in",
     "description": "This text is displayed as the title of our check-in cards"
   },
-  "cRj0sI": {
-    "defaultMessage": "Desculpe, mas houve um erro inesperado. Tente novamente mais tarde",
-    "description": "This message appears when the user tries to remove a given key-result, but receives an error"
-  },
-  "CS3a8I": {
-    "defaultMessage": "Ativo",
-    "description": "This option makes an active cycle"
-  },
   "Cu5tci": {
     "defaultMessage": "Se quiser, inclua uma descrição para ajudar seus colegas a entenderem por que esse resultado-chave é importante e como você pretende alcançá-lo.",
     "description": "This message is displayed as the placeholder for our second input in our key-result drawer"
   },
-  "CW+HBw": {
-    "defaultMessage": "",
-    "description": ""
-  },
-  "CWzl6a": {
-    "defaultMessage": "Nenhuma informação",
-    "description": "The fallback value appears if no value is defined for that text area. This text area is customizable, so it will only appears if no value is defined, and no custom fallback value was provided"
-  },
-  "cz6EUM": {
-    "defaultMessage": "Foto",
-    "description": "The label of the picture field in the create user form"
-  },
   "D22TnL": {
     "defaultMessage": "Responder",
     "description": "The text that goes in the answer routine button"
-  },
-  "d62Bt/": {
-    "defaultMessage": "Ícone de um balão de fala",
-    "description": "The description of the thinking balloon icon"
-  },
-  "d7EKd5": {
-    "defaultMessage": "Editar este OKR",
-    "description": "This is the second option that appears when you open the menu of a given objective inside the accordion button"
   },
   "D8ZyT4": {
     "defaultMessage": "Um ícone de coroa que representa a sua empresa",
@@ -995,49 +771,25 @@
     "defaultMessage": "Meta",
     "description": "This tooltip is displayed when the user hovers the right side value of our progress bar"
   },
-  "dB4Sbq": {
-    "defaultMessage": "Calculado pela média do progresso de todos os objetivos de um time e dos “sub-times” abaixo dele",
-    "description": "This tooltip appears when the user hovers the second column title"
-  },
   "DB7Ai9": {
     "defaultMessage": "Salvar",
     "description": "Text in the save action button"
-  },
-  "dbh5MZ": {
-    "defaultMessage": "OKRs {companypreposition} {company}",
-    "description": "Company OKR title of the page"
   },
   "DEMBaq": {
     "defaultMessage": "Um ícone com o sinal de positivo, indicando que ao clicar aqui você irá abrir o painel para inserir um resultado-chave",
     "description": "This message is used inside the objective accordion panel, on the insert key-result button"
   },
-  "dgMLta": {
-    "defaultMessage": "Enviar comentário",
-    "description": "This label is displayed in the submit button in our drawers"
-  },
-  "dH7eW3": {
-    "defaultMessage": "Progresso dos Times no {quarter}",
-    "description": "Title to show on the team ranking page when gamification is disabled"
-  },
   "DHoDPU": {
     "defaultMessage": "Salvar",
     "description": "This text is displayed as the button that will save the update for our goal update popover inside the key-result drawers"
   },
-  "DJm8nF": {
-    "defaultMessage": "Nenhuma pessoa encontrada",
-    "description": "This message is displayed when the key-result drawers update owner option user list has no users to display. This usually happens when the user tries to search but there is no results"
+  "DRyY0A": {
+    "defaultMessage": "Defina um desafio agressivo porém realista.",
+    "description": "The third description of the tip when you are creating a KR."
   },
-  "dLMgRx": {
-    "defaultMessage": "Aperte",
-    "description": "This message appears in the description of the submit the response button in the routines form."
-  },
-  "dlYnI1": {
-    "defaultMessage": "O time de apoio é uma ou mais pessoas que apoiam o responsável em um resultado-chave. No Bud, isso significa",
-    "description": "The message to guide and describe on what is a support team"
-  },
-  "DMwbJe": {
-    "defaultMessage": "Criar OKR",
-    "description": "create new key result"
+  "DWCNAb": {
+    "defaultMessage": "Passo 3",
+    "description": "The label of the third step while creating a new workspace"
   },
   "Dnh8iG": {
     "defaultMessage": "de <highlight>{confidence}</highlight>",
@@ -1051,109 +803,33 @@
     "defaultMessage": "Criar time",
     "description": "The text displayed inside create team button in explore page"
   },
-  "DRyY0A": {
-    "defaultMessage": "Defina um desafio agressivo porém realista.",
-    "description": "The third description of the tip when you are creating a KR."
-  },
   "DsPsDZ": {
     "defaultMessage": "Este time não possui nenhum subtime.",
     "description": "This message is displayed in our team plage inside the child teams section when that team has no child teams"
-  },
-  "duv/6P": {
-    "defaultMessage": "SENTIMENTO",
-    "description": "The title of the feeling graph"
-  },
-  "DWCNAb": {
-    "defaultMessage": "Passo 3",
-    "description": "The label of the third step while creating a new workspace"
   },
   "Dxj0ms": {
     "defaultMessage": "Email",
     "description": "This is the label that goes on our user account settings page, at the email field to update the user informations"
   },
-  "dymB9a": {
-    "defaultMessage": "Cada resultado-chave pertence a um objetivo",
-    "description": "This tooltip explains the second column of the key result list"
-  },
   "E+0+QH": {
     "defaultMessage": "Tem certeza que deseja excluir este resultado-chave?",
     "description": "This message is used as the title in our first dialog while removing a key-result"
-  },
-  "e+r00n": {
-    "defaultMessage": "Saiba mais",
-    "description": "A link to a page that talks about the retrospective routine."
-  },
-  "e2FL3I": {
-    "defaultMessage": "Um ícone do sinal de positivo que, ao clicar, irá adicionar um novo item na checklist",
-    "description": "This is used by screen readers to understand the insert new check mark icon in our key-result drawer"
-  },
-  "e37pvj": {
-    "defaultMessage": "Uma seta para baixo, indicando que ao clicar você irá abrir a lista de ciclos",
-    "description": "This message is displayed to the user screen reader when the year select menu is closed"
-  },
-  "e9PG+t": {
-    "defaultMessage": "por {author}",
-    "description": "This message displays the latest report author for a given component"
-  },
-  "eG8Ohg": {
-    "defaultMessage": "OKRs Anuais {year}",
-    "description": "The summary title for the yearly OKRs"
-  },
-  "EG9UsD": {
-    "defaultMessage": "OKRs da {company}",
-    "description": "Company OKR title of the page"
-  },
-  "eI6jYw": {
-    "defaultMessage": "Nenhuma informação",
-    "description": "The fallback value appears if no value is defined for that input. This input is customizable, so it will only appears if no value is defined, and no custom fallback value was provided"
-  },
-  "ej/Q3X": {
-    "defaultMessage": "Cancelar",
-    "description": "The button to close the modal cycle"
-  },
-  "EkoIl2": {
-    "defaultMessage": "Criar novo subtime",
-    "description": "This message appears as an option in the team page while adding a new user"
-  },
-  "epM1Xt": {
-    "defaultMessage": "Adicionar",
-    "description": "This button is used to create a new cycle."
-  },
-  "eQSkLB": {
-    "defaultMessage": "Essa semana",
-    "description": "This message appears with a subtitle in the cad that informs the user feeling status for the current week."
-  },
-  "ErVh0y": {
-    "defaultMessage": "Valor atual",
-    "description": "This is the label of the check-in form that indicates from which value the user would update her/his key result"
-  },
-  "eUCb55": {
-    "defaultMessage": "Fim",
-    "description": "The label text inside the Cycle section, above the end date in our key result single page or drawers"
-  },
-  "eVkwyH": {
-    "defaultMessage": "Minhas Coisas",
-    "description": "The page title that our users should see in the my things page"
-  },
-  "eVsyB5": {
-    "defaultMessage": "Email",
-    "description": "The label of the email field in the create user form"
-  },
-  "EvtBM8": {
-    "defaultMessage": "Progresso acumulado dessa semana",
-    "description": "This message is displayed weekly progress tag"
-  },
-  "eYhGZW": {
-    "defaultMessage": "Nenhuma opção disponível",
-    "description": "This message is displayed when the user tries to list the cycles, but none is defined"
   },
   "EZ8KCj": {
     "defaultMessage": "Email",
     "description": "The user email input placeholder while creating a new workspace"
   },
-  "f2OulU": {
-    "defaultMessage": "Início",
-    "description": "This message is displayed as the column header for the cycle table in the date start column"
+  "EkoIl2": {
+    "defaultMessage": "Criar novo subtime",
+    "description": "This message appears as an option in the team page while adding a new user"
+  },
+  "ErVh0y": {
+    "defaultMessage": "Valor atual",
+    "description": "This is the label of the check-in form that indicates from which value the user would update her/his key result"
+  },
+  "EvtBM8": {
+    "defaultMessage": "Progresso acumulado dessa semana",
+    "description": "This message is displayed weekly progress tag"
   },
   "F33Lyk": {
     "defaultMessage": "Cor do Nível de Confiança",
@@ -1163,53 +839,17 @@
     "defaultMessage": "Financeiro (Euro)",
     "description": "This message is displayed inside our key-result format select as the title of the coin EUR format"
   },
-  "f6/kwR": {
-    "defaultMessage": "Esse é o progresso acumulado dessa semana",
-    "description": "This tooltip appears when the user hovers the third column title"
-  },
-  "f6KTde": {
-    "defaultMessage": "Ações",
-    "description": "This message is displayed as the column header for the users table in the actions column"
-  },
   "F9UdBv": {
     "defaultMessage": "Ações",
     "description": "This message is displayed as the column header for the cycle table in the actions column"
-  },
-  "faL9vf": {
-    "defaultMessage": "Um círculo verde, indicando que a confiança está alta",
-    "description": "A brief explanation for screen readers regarding the green status circle"
-  },
-  "Fb0ZAK": {
-    "defaultMessage": "Devem descrever uma visão de futuro atraente e motivante que valha a pena o esforço para alcançar.",
-    "description": "This card guides the creation of Objectives."
-  },
-  "fd6kjy": {
-    "defaultMessage": "Resultado-chave",
-    "description": "The text of the table head related to the KeyResult column"
   },
   "FEd9u8": {
     "defaultMessage": "Salvar",
     "description": "This message is displayed in the \"SAVE\" button in the checkin form"
   },
-  "ff3h07": {
-    "defaultMessage": "Baixa Confiança",
-    "description": "We use this tag to group every key result with confidence higher than 33 but lower than 66"
-  },
-  "fFkPeH": {
-    "defaultMessage": "Cargo",
-    "description": "The user role input placeholder while creating a new workspace"
-  },
-  "fI4P80": {
-    "defaultMessage": "Q1",
-    "description": "This button appears as an empty state while the user is selecting the cycle filter"
-  },
   "FMvbXp": {
     "defaultMessage": "No ciclo {cadence} {cycle} {parent}",
     "description": "This message is displayed inside the team page, on the options menu of a cycle"
-  },
-  "FoCix/": {
-    "defaultMessage": "Procurar",
-    "description": "The text is displayed as the default placeholder for all our search inputs"
   },
   "FPhsI3": {
     "defaultMessage": "Selecione seus times",
@@ -1223,49 +863,21 @@
     "defaultMessage": "Você perderá todos os check-ins e comentários feitos até aqui.",
     "description": "This message is used as the description in our first dialog while removing a key-result"
   },
-  "fsAK9T": {
-    "defaultMessage": "Selecionar...",
-    "description": "This message appears in the input when no user is selected."
-  },
-  "fv5OeR": {
-    "defaultMessage": "{confidence, select, roadblock {Todos os resultados-chave {confidence}} other {Todos os resultados-chave de {confidence}}}",
-    "description": "The title for the dashboard key results modal"
-  },
   "FVnpVq": {
     "defaultMessage": "Um ícone de seta para o lado direito, meramente ilustrativo",
     "description": "The alternative text explaining our arrow right icon"
-  },
-  "fVyP58": {
-    "defaultMessage": "Visualize os objetivos e resultados-chave de todos os times dessa área, se aprofunde no detalhamento de progresso, nível de confiança e dono.",
-    "description": "The page description that is displayed in Google and screen readers"
-  },
-  "fwIpqP": {
-    "defaultMessage": "Visualize e atualize as preferências do seu perfil",
-    "description": "The page description that is displayed in Google and screen readers for the my profile page"
   },
   "FWsiRf": {
     "defaultMessage": "{confidence, select, barrier {Todos os resultados-chave {confidencetext}} other {Todos os resultados-chave de {confidencetext}}}",
     "description": "The title for the dashboard key results modal"
   },
-  "fx39XE": {
-    "defaultMessage": "Ajuda",
-    "description": "This tooltip is displayed when the user hovers the support button"
+  "Fb0ZAK": {
+    "defaultMessage": "Devem descrever uma visão de futuro atraente e motivante que valha a pena o esforço para alcançar.",
+    "description": "This card guides the creation of Objectives."
   },
-  "fX4pLO": {
-    "defaultMessage": "Configurações da plataforma | bud",
-    "description": "The page title that is displayed in the browser tab for the platform settings page"
-  },
-  "fYwrtN": {
-    "defaultMessage": "Essa semana",
-    "description": "This message appears with a subtitle in the cad that informs the user productivity status for the current week."
-  },
-  "FZVBXg": {
-    "defaultMessage": "Adicionar nova tarefa",
-    "description": "The add new personal task button label"
-  },
-  "fZZOsX": {
-    "defaultMessage": "Fim",
-    "description": "The label text inside the Cycle section, above the end date in our key result single page or drawer"
+  "FoCix/": {
+    "defaultMessage": "Procurar",
+    "description": "The text is displayed as the default placeholder for all our search inputs"
   },
   "G/bGAZ": {
     "defaultMessage": "Ambiente criado com sucesso",
@@ -1275,21 +887,17 @@
     "defaultMessage": "O acesso desta pessoa ao Bud foi desativado.",
     "description": "This message appears in the tooltip of users with inactive account state."
   },
-  "gAgkzF": {
-    "defaultMessage": "Criar Objetivo",
-    "description": "create new key result"
-  },
-  "ganP5k": {
-    "defaultMessage": "Settings | bud",
-    "description": "The page title that is displayed in the browser tab for the settings page"
-  },
   "GBh0Xf": {
     "defaultMessage": "Desculpe, mas já existe um usuário com este e-mail",
     "description": "This message is used as an toast error message when we try to create an user with an existing e-mail"
   },
-  "gbO+eS": {
-    "defaultMessage": "Se realmente tem certeza de que deseja fazer isso, confirme sua ação escrevendo \"{keyword}” no campo abaixo:",
-    "description": "This message is used as our default second stage description in our dangerous confirmation modal"
+  "GHu/pe": {
+    "defaultMessage": "Um ícone de video",
+    "description": "The desc message for the Video icon. This icon is used to ilustrate our key results"
+  },
+  "GKl+a6": {
+    "defaultMessage": "Desativar conta",
+    "description": "This message is the description of the option to deactivate a user account."
   },
   "GeAU92": {
     "defaultMessage": "Um ícone de configurações. Ao clicar nele você irá para a tela de configurações da nossa plataforma",
@@ -1303,49 +911,13 @@
     "defaultMessage": "Uma mão apertando um botão com um icone de seleção de uma tarefa",
     "description": "The alternative text explaining the check item image"
   },
-  "GHeIgq": {
-    "defaultMessage": "Faz um tempo que ninguém interage por aqui. Que tal compartilhar algo sobre o progresso desse resultado-chave com o time? :)",
-    "description": "This text gives more details regarding our empty state card in the key result drawer"
-  },
-  "GHu/pe": {
-    "defaultMessage": "Um ícone de video",
-    "description": "The desc message for the Video icon. This icon is used to ilustrate our key results"
-  },
-  "gioO8X": {
-    "defaultMessage": "Plataforma",
-    "description": "The page title that our users should see in the platform settings page"
-  },
   "Gk28Al": {
     "defaultMessage": "novo!",
     "description": "Tag new item"
   },
-  "GKl+a6": {
-    "defaultMessage": "Desativar conta",
-    "description": "This message is the description of the option to deactivate a user account."
-  },
-  "gm1hfm": {
-    "defaultMessage": "Progresso do objetivo acumulado na semana",
-    "description": "This tooltip explains regarding our progress tag"
-  },
-  "gMArPa": {
-    "defaultMessage": "O Bud enviará lembretes para este time por email e por notificações para que todos respondam.",
-    "description": "Routine notification settings description subtitle"
-  },
   "GnbGX+": {
     "defaultMessage": "Sem resposta na semana passada",
     "description": "The outdated text that goes in the update text, below the routine title, when the routine is outdated."
-  },
-  "gODdaE": {
-    "defaultMessage": "Bem-vind{gender, select, MALE {o} FEMALE {a} other {o}} de volta, {name} :)",
-    "description": "The page title that our users should see in the dashboard page"
-  },
-  "gOltd4": {
-    "defaultMessage": "Um ícone de seta para a direita que indica que o usuário pode avançar no histórico para conferir outras respostas da rotina.",
-    "description": "The alternative text explaining our graphic icon"
-  },
-  "goSPM7": {
-    "defaultMessage": "Você excluiu um {type}",
-    "description": "This text is displayed as the alert title, explaining what resource the user removed"
   },
   "GqZyEx": {
     "defaultMessage": "POR TIME",
@@ -1359,29 +931,9 @@
     "defaultMessage": "Página não encontrada | bud",
     "description": "The page title of our not found error page that is displayed in the browser tab"
   },
-  "GtgPfn": {
-    "defaultMessage": "Procurar",
-    "description": "The text is displayed as a placeholder in our search input inside the key-result drawers while the user is changing the owner of that key-result"
-  },
-  "gTym4f": {
-    "defaultMessage": "Progresso individual com base na média dos resultados-chave deste ano",
-    "description": "Yearly progress chart tooltip message"
-  },
-  "gu4aCE": {
-    "defaultMessage": "Anual",
-    "description": "This text is used as prefix for our yearly cadences"
-  },
   "GuD4W6": {
     "defaultMessage": "Plano Individual",
     "description": "Individual OKR title of the page"
-  },
-  "gUHlz3": {
-    "defaultMessage": "Seja o primeiro a comentar a resposta de {user}!",
-    "description": "This message appears in the empty state of comments in a user retrospective reply."
-  },
-  "gXiIKg": {
-    "defaultMessage": "Baixa confiança",
-    "description": "Title of low confidence health strategy"
   },
   "GyV44g": {
     "defaultMessage": "Resultados-Chave",
@@ -1391,10 +943,6 @@
     "defaultMessage": "Confirmação de segurança",
     "description": "This message is displayed as the input label for the danger confirmation resource dialog"
   },
-  "gZstKN": {
-    "defaultMessage": "Estado inicial",
-    "description": "The description for state cycle field on create cycle form"
-  },
   "H/aZym": {
     "defaultMessage": "Escolha como suas informações aparecerão para os outros usuários.",
     "description": "This subtitle is displayed as the subtitle of the personal informations section in our user account settings page"
@@ -1402,10 +950,6 @@
   "H/tYPn": {
     "defaultMessage": "{name} perderá o acesso ao Bud e será removido dos times aos quais pertence, mas manteremos o histórico de check-ins e comentários feitos até aqui.",
     "description": "This message appears in the confirmation dialog when we try to deactivate an user."
-  },
-  "h/WXZ6": {
-    "defaultMessage": "resultado-chave",
-    "description": "This message is used as the type to display in some of the delete dialogs while removing a given key-result"
   },
   "H0xYvz": {
     "defaultMessage": "Estes são os resultados-chave e as tarefas atribuídos a {username}.",
@@ -1415,85 +959,13 @@
     "defaultMessage": "A calendar icon",
     "description": "The calendar icon description that goes in the routine reminder notification"
   },
-  "h4sP/q": {
-    "defaultMessage": "Minha conta",
-    "description": "The page title that our users should see in the my profile page"
-  },
-  "h4VH9f": {
-    "defaultMessage": "desativar usuário",
-    "description": "This message appears in button to confirm the deactivate user action."
-  },
-  "h6wsCP": {
-    "defaultMessage": "Um ícone de seta para a esquerda que indica que o usuário pode retroceder no histórico para conferir outras respostas da rotina.",
-    "description": "The alternative text explaining our graphic icon"
-  },
   "HAQ+JV": {
     "defaultMessage": "Um círculo vermelho, indicando que a confiança está baixa",
     "description": "A brief explanation for screen readers regarding the red status circle"
   },
-  "hdWCC9": {
-    "defaultMessage": "Próximo",
-    "description": "The label of the button used to go forward while creating a new workspace"
-  },
   "HEYvPI": {
     "defaultMessage": "Criar Resultado Chave",
     "description": "This message appears as the title of the insert Key Result drawer"
-  },
-  "Hfg9tY": {
-    "defaultMessage": "Confirmar",
-    "description": "This text is used as a fallback to the confirmation modal confirm button. It is displayed if the component did not received a custom button label"
-  },
-  "hFma0o": {
-    "defaultMessage": "Erro ao criar o ambiente",
-    "description": "The title of the toast that appears when we have an error while creating a new workspace"
-  },
-  "hfxyjh": {
-    "defaultMessage": "Veja nossos exemplos de OKRs",
-    "description": "This is a external link that goes to OKR examples made by Bud."
-  },
-  "hhH9fH": {
-    "defaultMessage": "Cargo do usuário inicial",
-    "description": "The user role while creating a new workspace"
-  },
-  "HhSnBG": {
-    "defaultMessage": "DESATIVAR",
-    "description": "This is the keyword that the user needs to type to deactivate a given user"
-  },
-  "hJZjes": {
-    "defaultMessage": "Check-in em dia",
-    "description": "The title of the section of the key results with an up to date check-in."
-  },
-  "hL/jUm": {
-    "defaultMessage": "TAREFAS EM OKRs",
-    "description": "The title for tasks section in the profile page"
-  },
-  "hMD8CO": {
-    "defaultMessage": "Anterior",
-    "description": "The label of the button used to go back while creating a new workspace"
-  },
-  "hMXuTX": {
-    "defaultMessage": "Masculino",
-    "description": "This text is used accross our platform to identify the male gender"
-  },
-  "hn3cE7": {
-    "defaultMessage": "Progresso acumulado dessa semana",
-    "description": "This helper texts explains since when we are calculating your company progress"
-  },
-  "hohkHN": {
-    "defaultMessage": "Criar time",
-    "description": "The text is displayed as a heading in the add team modal"
-  },
-  "HOpxw5": {
-    "defaultMessage": "Plataforma",
-    "description": "This message is used in the sidebar of our settings page"
-  },
-  "how6b8": {
-    "defaultMessage": "Um ícone de seta para a direita, usado no contexto de um link que redireciona o usuário para a página onde fala sobre a rotina de retrospectiva.",
-    "description": "A right arrow icon, used in the context of a link that redirects the user to the page where the retrospective routine is discussed."
-  },
-  "hPJxpx": {
-    "defaultMessage": "Média Confiança",
-    "description": "We use this tag to group every key result with confidence higher than 33 but lower than 66"
   },
   "HQfOOa": {
     "defaultMessage": "Ciclo",
@@ -1503,25 +975,13 @@
     "defaultMessage": "Adicionar membro ao time",
     "description": "This is the title of the modal that is used to add members to a team."
   },
+  "HhSnBG": {
+    "defaultMessage": "DESATIVAR",
+    "description": "This is the keyword that the user needs to type to deactivate a given user"
+  },
   "HsEMwj": {
     "defaultMessage": "Uma seta longa para a direita, separando o progresso anterior (à esquerda) do novo progress do check-in (à direita)",
     "description": "This text is displayed to screen readers, explaining the right arrow icon in our check-in card"
-  },
-  "huUzRi": {
-    "defaultMessage": "custom emoji with apathetic expression",
-    "description": "This message is used as a description of emoji feeling 2"
-  },
-  "hwBdQ9": {
-    "defaultMessage": "Começar",
-    "description": "This message appears on the button the user uses to start responding to the routine form."
-  },
-  "hXlVqV": {
-    "defaultMessage": "Minhas Tarefas Pessoais",
-    "description": "The heading for the personal tasks section"
-  },
-  "hzOI/d": {
-    "defaultMessage": "Se realmente tem certeza de que deseja excluir este {type}, confirme sua ação escrevendo “EXCLUIR” no campo abaixo:",
-    "description": "This message is displayed as the description for the danger confirmation modal while removing a given resource"
   },
   "I+MSuS": {
     "defaultMessage": "Ver menos...",
@@ -1531,14 +991,6 @@
     "defaultMessage": "Ícone de filtro com 3 linhas",
     "description": "The description of three layer icon that filters the answer search."
   },
-  "i3PQl+": {
-    "defaultMessage": "Ciclo {period} {status} com sucesso!",
-    "description": "This message appears when we create a new cycle as a toast"
-  },
-  "i7i3Ew": {
-    "defaultMessage": "reportou {specific} resultado-chave:",
-    "description": "This message is the wrapper that appears on both types of confidence check ins."
-  },
   "I7MY1s": {
     "defaultMessage": "Notificações",
     "description": "Tooltip title of the notification bell."
@@ -1547,25 +999,9 @@
     "defaultMessage": "Check-in realizado",
     "description": "This string is used as the description for the icon that indicates that the key-result is updated"
   },
-  "i915bK": {
-    "defaultMessage": "Líderes podem criar, editar e excluir objetivos e resultados-chave dos times aos quais pertencem.",
-    "description": "This string is used to describe the user edit role selection."
-  },
-  "i9bdpU": {
-    "defaultMessage": "Houve um erro inesperado ao criar seu objetivo. Tente novamente mais tarde",
-    "description": "This message appears as an error toast when the users tries to create a new objective but an error appears"
-  },
   "ICcB35": {
     "defaultMessage": "Minha semana",
     "description": "This message appears as the title of the Check-ins and routine option in the notifications modal."
-  },
-  "ifl8WA": {
-    "defaultMessage": "Você ainda não criou nenhum OKR Individual.",
-    "description": "This message is displayed as the empty state message inside the User page"
-  },
-  "IfVw1+": {
-    "defaultMessage": "Semana",
-    "description": "The text that appears at the week description"
   },
   "IGHT6z": {
     "defaultMessage": "Você perderá todos os resultados-chave deste OKR, incluindo todos os check-ins e comentários feitos até aqui.",
@@ -1579,45 +1015,25 @@
     "defaultMessage": "Responsável",
     "description": "The label text above the Owner section in our key result single page or drawers"
   },
-  "Ii3n+d": {
-    "defaultMessage": "para <highlight>{confidence}</highlight>",
-    "description": "This text is displayed as the second line of our confidence tooltip"
-  },
-  "iIm/1E": {
-    "defaultMessage": "marcou você em um comentário:",
-    "description": "This message is displayed to describe a notification that occurs when a user is tagged in a comment."
-  },
-  "iivI51": {
-    "defaultMessage": "Neste mês",
-    "description": "This label is displayed if the date difference is 1 month or less"
-  },
-  "ijCibq": {
-    "defaultMessage": "Financeiro (Dólar)",
-    "description": "This message is displayed inside our key-result format select as the title of the coin USD format"
-  },
-  "iJq7du": {
-    "defaultMessage": "Responsável",
-    "description": "The label text above the Owner section in our key result single page or drawer"
-  },
-  "iLO8sl": {
-    "defaultMessage": "Estas tarefas não estão relacionadas diretamente a um resultado-chave. Use-as para organizar melhor seu dia e deixá-lo mais produtivo :)",
-    "description": "The tooltip that shows when hovering over the personal tasks accordion title"
-  },
-  "ilU+Uz": {
-    "defaultMessage": "Meu perfil",
-    "description": "The page title that our users should see in the my profile page"
-  },
-  "Innace": {
-    "defaultMessage": "Um ícone de exclamação, alertando que se você confirmar a ação não poderá ser desfeita",
-    "description": "This text is used by screen readers to explain the icon"
-  },
   "INrEzv": {
     "defaultMessage": "Masculino",
     "description": "This is the male option while selecting a gender to create a new user"
   },
-  "iPv+uj": {
-    "defaultMessage": "Um ícone de uma linha reta na horizontal, representando que sua empresa não evolui desde o último evento de check-in",
-    "description": "This message is used by screen readers to explain our line icon"
+  "IU2bu6": {
+    "defaultMessage": "Escreva {keyword} para confirmar sua ação",
+    "description": "This message appears as a placeholder on the input in the danger confirmation modal while deleting a given resource"
+  },
+  "IWr6NM": {
+    "defaultMessage": "€ 100",
+    "description": "This message is displayed inside our key-result format select as the example of the coin EUR format"
+  },
+  "IfVw1+": {
+    "defaultMessage": "Semana",
+    "description": "The text that appears at the week description"
+  },
+  "Ii3n+d": {
+    "defaultMessage": "para <highlight>{confidence}</highlight>",
+    "description": "This text is displayed as the second line of our confidence tooltip"
   },
   "IsUZSc": {
     "defaultMessage": "Excluir este Resultado-Chave",
@@ -1627,26 +1043,6 @@
     "defaultMessage": "Check-in realizado",
     "description": "This message is displayed alongisde with the key-result name, as the prefix for our last update text component"
   },
-  "IU2bu6": {
-    "defaultMessage": "Escreva {keyword} para confirmar sua ação",
-    "description": "This message appears as a placeholder on the input in the danger confirmation modal while deleting a given resource"
-  },
-  "iVxx6N": {
-    "defaultMessage": "Essa semana",
-    "description": "This message appears with a subtitle in the cad that informs the user barrier status for the current week."
-  },
-  "iWDn4y": {
-    "defaultMessage": "Time de Apoio",
-    "description": "The label text above Support Team section in our key resulg single page or drawers"
-  },
-  "IWr6NM": {
-    "defaultMessage": "€ 100",
-    "description": "This message is displayed inside our key-result format select as the example of the coin EUR format"
-  },
-  "iZcwRX": {
-    "defaultMessage": "ACESSO DE EDIÇÃO",
-    "description": "The tooltip text for the edition access text"
-  },
   "J+UxkH": {
     "defaultMessage": "{progress, select, 0 {Sem variação} other {Variação de <highlight>{signal}{progress}%</highlight>}}",
     "description": "This label appears in our stamp title. It represents how much your company has increased since last week"
@@ -1654,10 +1050,6 @@
   "J0sAff": {
     "defaultMessage": "Ciclo {period} excluído com sucesso.",
     "description": "This message appears in a toast after the user removes an cycle."
-  },
-  "j1c4SD": {
-    "defaultMessage": "PRODUTIVIDADE",
-    "description": "The title of the productivity graph"
   },
   "J3ARiQ": {
     "defaultMessage": "OKR Master",
@@ -1671,33 +1063,9 @@
     "defaultMessage": "Ícone de pausa representando a quantidade de OKRs com barreiras que a empresa tem",
     "description": "The description of the with barrier icon"
   },
-  "J8dAid": {
-    "defaultMessage": "Este objetivo não tem nenhum resultado-chave",
-    "description": "This message is displayed in the key-results empty state inside the team page when an objective has no key-results"
-  },
-  "j8vYyP": {
-    "defaultMessage": "Rotinas da empresa estão sempre disponíveis para quem quiser responder, mas líderes podem desativar os lembretes para tornar as respostas opcionais em seu time.",
-    "description": "Routine notification settings modal subtitle"
-  },
   "JBA9+L": {
     "defaultMessage": "Explorar ciclos anteriores",
     "description": "This text is displayed as a tab where the user can click to change the view below it"
-  },
-  "Jc/lcm": {
-    "defaultMessage": "Progresso esperado: {progress}%",
-    "description": "The tooltip content for the projected progress thumb"
-  },
-  "jCjr1X": {
-    "defaultMessage": "Preencha os campos obrigatórios para poder salvar este resultado-chave.",
-    "description": "This message appears in an error toast after the users tries to create a key-result but there are some validation errors in the form"
-  },
-  "JcoCf/": {
-    "defaultMessage": "Média da semana",
-    "description": "The description of the radial graph that indicates the week mean"
-  },
-  "Jdklxm": {
-    "defaultMessage": "O desenho de um fantasma, ilustrando que você está em uma página que não existe",
-    "description": "This message is the alt message for our box drawing in the not found error page"
   },
   "JHyn+l": {
     "defaultMessage": "Essa ação não pode ser desfeita",
@@ -1707,13 +1075,33 @@
     "defaultMessage": "Coisas de {username}",
     "description": "The page title for users profile"
   },
+  "JKqe2t": {
+    "defaultMessage": "Uma caixa vazia.",
+    "description": "The alternative text explain the empty state message from notifications list."
+  },
+  "JNiINj": {
+    "defaultMessage": "Veja nossos exemplos de OKRs",
+    "description": "This button redirects to the page that teaches about OKRs."
+  },
+  "JZJeBS": {
+    "defaultMessage": "Ontem",
+    "description": "This label is displayed if the last is yesterday"
+  },
+  "Jc/lcm": {
+    "defaultMessage": "Progresso esperado: {progress}%",
+    "description": "The tooltip content for the projected progress thumb"
+  },
+  "JcoCf/": {
+    "defaultMessage": "Média da semana",
+    "description": "The description of the radial graph that indicates the week mean"
+  },
+  "Jdklxm": {
+    "defaultMessage": "O desenho de um fantasma, ilustrando que você está em uma página que não existe",
+    "description": "This message is the alt message for our box drawing in the not found error page"
+  },
   "Jj0rRJ": {
     "defaultMessage": "Administradores possuem acesso total de criação, edição e exclusão de OKRs, usuários e ciclos de estratégia.",
     "description": "This string is used to describe the user admin role selection."
-  },
-  "jjr+Ye": {
-    "defaultMessage": "O objetivo foi removido com sucesso",
-    "description": "This message appears in a toast after the user removes an objective"
   },
   "Jk/gDc": {
     "defaultMessage": "Criar objetivo",
@@ -1723,65 +1111,17 @@
     "defaultMessage": "US$ 100",
     "description": "This message is displayed inside our key-result format select as the example of the coin USD format"
   },
-  "JKqe2t": {
-    "defaultMessage": "Uma caixa vazia.",
-    "description": "The alternative text explain the empty state message from notifications list."
-  },
   "Jl5nlI": {
     "defaultMessage": "custom emoji with sad expression",
     "description": "This message is used as a description of emoji feeling 1"
   },
-  "JNiINj": {
-    "defaultMessage": "Veja nossos exemplos de OKRs",
-    "description": "This button redirects to the page that teaches about OKRs."
-  },
-  "jNuy4b": {
-    "defaultMessage": "Esta pessoa tem acesso ao Bud.",
-    "description": "This message appears in the tooltip of users with active account state."
-  },
-  "jRsXuq": {
-    "defaultMessage": "CHECK-INS",
-    "description": "The tooltip text for the check-ins text"
-  },
-  "jV4VhD": {
-    "defaultMessage": "Excluir ciclo",
-    "description": "This message is used as the label in the confirmation button while removing a cycle"
-  },
-  "jvxLB+": {
-    "defaultMessage": "Você tem certeza que deseja fazer isso? Essa ação é irreversível",
-    "description": "This text is used as a fallback to the confirmation modal title. It is displayed if the component did not received a custom message to display"
-  },
-  "jwsMer": {
-    "defaultMessage": "Último check-in",
-    "description": "the prefix that is displayed in the last update checkmark."
+  "Jw9V43": {
+    "defaultMessage": "Opções",
+    "description": "This message appears how description to menu action options"
   },
   "Jx/tRY": {
     "defaultMessage": "Nome do time:",
     "description": "The label to the team name field in team add/edit modal"
-  },
-  "jxyYl3": {
-    "defaultMessage": "Ordenada pelo progresso",
-    "description": "This tooltip appears when the user hovers the first column title"
-  },
-  "jXZZd6": {
-    "defaultMessage": "Voltar ao presente",
-    "description": "go back to the present button description"
-  },
-  "JYkjjF": {
-    "defaultMessage": "Meu perfil",
-    "description": "This label defines the text on the first menu section option"
-  },
-  "jYw0F3": {
-    "defaultMessage": "Membros do time {isLoaded, select, true {({totalMembersCount})} other{}}",
-    "description": "This message is displayed inside the explore page, above the members section"
-  },
-  "JZJeBS": {
-    "defaultMessage": "Ontem",
-    "description": "This label is displayed if the last is yesterday"
-  },
-  "jzx+Hl": {
-    "defaultMessage": "Botão de opções",
-    "description": "This button allows you to choose an option that directs the user to the users profile or details."
   },
   "K03Z5V": {
     "defaultMessage": "Período",
@@ -1791,18 +1131,6 @@
     "defaultMessage": "NOTIFICAÇÕES",
     "description": "The tooltip text for the notifications text"
   },
-  "k0fMvn": {
-    "defaultMessage": "Escreva sobre você",
-    "description": "This is the fallback value that goes on our user account settings page, at the seventh field to update the user informations. The fallback value appears if the user has no data at that field"
-  },
-  "k3EFXK": {
-    "defaultMessage": "O nível de confiança descreve como você vê suas chances de alcançar esse resultado-chave dentro do prazo",
-    "description": "The tooltip of the check-in form. It appears when the user hovers the question mark icon"
-  },
-  "k4LTU8": {
-    "defaultMessage": "Dia de fim do período trimestral",
-    "description": "The label of the company quarterly date end while creating a new workspace"
-  },
   "K4Rjji": {
     "defaultMessage": "Histórico",
     "description": "Title of the history button"
@@ -1811,81 +1139,21 @@
     "defaultMessage": "Minhas Coisas",
     "description": "MainAppBar menu item that links to \"My Things\" page"
   },
-  "kawRcN": {
-    "defaultMessage": "Cancelar",
-    "description": "This message is displayed in the \"CANCEL\" button in the checkin form"
-  },
-  "kAwViv": {
-    "defaultMessage": "Compartilhe suas as prioridades, conquistas e barreiras com seu time. Acompanhe e interaja com seus colegas sobre a jornada deles.",
-    "description": "Description of the content of the Retrospective tab on the teams page."
-  },
-  "kbccVO": {
-    "defaultMessage": "Seta para esquerda",
-    "description": "The description of the arrow icon."
-  },
-  "kDC8d3": {
-    "defaultMessage": "Configurações",
-    "description": "The page title that our users should see in the settings page"
-  },
   "KDE9dq": {
     "defaultMessage": "Se realmente tem certeza de que deseja excluir o ciclo {period} e todos os seus OKRs, confirme sua ação escrevendo “EXCLUIR” no campo abaixo:",
     "description": "This message is used as the description in our  second dialog while removing a cycle"
-  },
-  "KdYFbe": {
-    "defaultMessage": "Apagar",
-    "description": "This text is displayed in our menu, as an anchor to remove that given card"
-  },
-  "kEofXd": {
-    "defaultMessage": "O planejamento individual é definido por você. Eles não interferem no progresso da empresa, mas podem ser vistos por seus colegas.",
-    "description": "Individual OKR subtitle of the page"
-  },
-  "kFrglO": {
-    "defaultMessage": "O progresso do objetivo é calculado pela média de evolução dos seus resultados-chave. É preciso atingir todos esses resultados para alcançar o objetivo. Por isso, a cor desse indicador reflete a menor confiança entre seus resultados-chave.",
-    "description": "This tooltip explains how the progress of the objective is calculated"
   },
   "KGQV/U": {
     "defaultMessage": "Nome",
     "description": "The company name input placeholder while creating a new workspace"
   },
-  "kHg/gs": {
-    "defaultMessage": "Você não tem nenhum resultado-chave em ciclos anteriores",
-    "description": "The label message that is displayed below our team at work image when the user has no key results in her/his key result view list"
-  },
-  "kjKwCU": {
-    "defaultMessage": "Comentários:",
-    "description": "This message appears as the empty state title of comments in a user retrospective reply"
-  },
-  "kLkKtK": {
-    "defaultMessage": "Um círculo amarelo, indicando que a confiançá é média",
-    "description": "A brief explanation for screen readers regarding the yellow status circle"
-  },
-  "kOLcvX": {
-    "defaultMessage": "Clique aqui para comentar :)",
-    "description": "This text is displayed in our comment input in our key result drawers when it has no value"
-  },
-  "kpJFIH": {
-    "defaultMessage": "Um ícone de lupa, indicando que este é um campo de busca",
-    "description": "This text is used by screen readers to explain the icon to the user. It is located in the key-result drawers, inside the edit owner component, as a description for the search icon"
-  },
   "KSjqcC": {
     "defaultMessage": "%",
     "description": "The text of the table head related to the percentual progress column"
   },
-  "kTFIMk": {
-    "defaultMessage": "Você não tem check-ins pendentes porque não está envolvido em nenhum resultado-chave.",
-    "description": "The page description that is displayed if the user has no key result in the check in notifications tab."
-  },
-  "kXNgkQ": {
-    "defaultMessage": "Progresso",
-    "description": "The text of the table head related to the Progress column"
-  },
-  "kynYpx": {
-    "defaultMessage": "Meus Resultados-Chave",
-    "description": "The page title that our users should see in the my key results page"
-  },
-  "l+HPdy": {
-    "defaultMessage": "Líder",
-    "description": "The tag title that is displayed when that user is the leader of the team"
+  "KdYFbe": {
+    "defaultMessage": "Apagar",
+    "description": "This text is displayed in our menu, as an anchor to remove that given card"
   },
   "L/b/G/": {
     "defaultMessage": "Um desenho de uma pasta aberta sem nada dentro",
@@ -1907,89 +1175,25 @@
     "defaultMessage": "Adicionar nova tarefa a este KR",
     "description": "The label for create KR task button"
   },
-  "lApj0K": {
-    "defaultMessage": "Um ícone de carteira",
-    "description": "The desc message for the Wallet icon. This icon is used to ilustrate our key results"
-  },
-  "lBc00A": {
-    "defaultMessage": "Descreve o quão confiante a pessoa responsável por um resultado-chave está:",
-    "description": "This message is displayed as an introduction to our rich tooltip regarding the confidence level at the head of our key-results table"
-  },
-  "Lc60Nd": {
-    "defaultMessage": "Posição atual",
-    "description": "This message is displayed below the current progress thumb"
-  },
-  "lCQz97": {
-    "defaultMessage": "Período",
-    "description": "The company yearly period input placeholder while creating a new workspace"
-  },
   "LDLFtf": {
     "defaultMessage": "Sobre {isMyUser, select, true {você} other {{gender, select, MALE {o} FEMALE {a} other {o}} {firstName}}}",
     "description": "This is the label that goes on our user account settings page, at the seventh field to update the user informations"
-  },
-  "lf4c2p": {
-    "defaultMessage": "objetivo",
-    "description": "This message is used as our resource type while removing a objective"
-  },
-  "lHI54p": {
-    "defaultMessage": "Para adicionar a este time uma pessoa que já tem acesso ao Bud, use o campo abaixo:",
-    "description": "This is the description of the modal that is used to add members to a team."
-  },
-  "lhIu1G": {
-    "defaultMessage": "€ 100",
-    "description": "This message is displayed inside our key-result format select as the example of the coin GBP format"
-  },
-  "LhZDKa": {
-    "defaultMessage": "Enviar",
-    "description": "The label of the button used to submit a new workspace"
-  },
-  "lI5vJI": {
-    "defaultMessage": "Um ícone com três pontos. Ao clicar nele você abrirá algumas opções",
-    "description": "This text is displayed as the tree dots desc text in our timeline cards"
-  },
-  "ll4kYl": {
-    "defaultMessage": "Data de fim",
-    "description": "The description for date-end cycle field"
-  },
-  "lm9HAr": {
-    "defaultMessage": "Um ícone de calendário",
-    "description": "The desc message for the Calendar icon. This icon is used to ilustrate our key results"
-  },
-  "lMwPEm": {
-    "defaultMessage": "Inglês",
-    "description": "This is the name of the english language while we are creating a new user"
-  },
-  "lMxUF9": {
-    "defaultMessage": "Um ícone de seta para baixo, indicando que o progresso reduziu",
-    "description": "This desc message explains the decrease icon for screen readers"
-  },
-  "lMYmAU": {
-    "defaultMessage": "Clique no botão abaixo para voltar para o Painel :)",
-    "description": "This message is displayed above the button in our not found error page"
-  },
-  "Ln2GmC": {
-    "defaultMessage": "Gênero",
-    "description": "The user gender input placeholder while creating a new workspace"
-  },
-  "loAGsF": {
-    "defaultMessage": "Variação",
-    "description": "This text is displayed in our check-in card, as a title for the left column in the progress increase section"
-  },
-  "loTYpj": {
-    "defaultMessage": "Inglês",
-    "description": "The user locale en-US option while creating a new workspace"
-  },
-  "lpsQj3": {
-    "defaultMessage": "Check-in",
-    "description": "This message appears as the title of the Check-ins option in the notifications modal."
   },
   "LQfRhU": {
     "defaultMessage": "Ir para o perfil",
     "description": "This message is the description of the option to redirect to profile of a user."
   },
-  "lQkUTL": {
-    "defaultMessage": "Inspiradores",
-    "description": "This title guides the creation of Objectives."
+  "Lc60Nd": {
+    "defaultMessage": "Posição atual",
+    "description": "This message is displayed below the current progress thumb"
+  },
+  "LhZDKa": {
+    "defaultMessage": "Enviar",
+    "description": "The label of the button used to submit a new workspace"
+  },
+  "Ln2GmC": {
+    "defaultMessage": "Gênero",
+    "description": "The user gender input placeholder while creating a new workspace"
   },
   "Lt+YEZ": {
     "defaultMessage": "Fim",
@@ -1998,14 +1202,6 @@
   "LvI+KK": {
     "defaultMessage": "Idioma",
     "description": "This message is the label of our locale switcher in the settings page"
-  },
-  "lWcm/y": {
-    "defaultMessage": "Não existem resultados-chave com esse Nível de confiança.",
-    "description": "Tooltip content for health strategy box without key results"
-  },
-  "LwoUMm": {
-    "defaultMessage": "Plano individual",
-    "description": "Individual OKR title of the page"
   },
   "Lxrv+d": {
     "defaultMessage": "Criar Ciclo",
@@ -2019,14 +1215,6 @@
     "defaultMessage": "Sem check-in",
     "description": "This message is displayed alongisde with the key-result name, as the prefix for our last update text component"
   },
-  "m4igWj": {
-    "defaultMessage": "Adicionar Comentário",
-    "description": "This is the label text that is displayed as a button as soon the check in form is displayed"
-  },
-  "m8Extk": {
-    "defaultMessage": "Um ícone de scanner",
-    "description": "The desc message for the Scan icon. This icon is used to ilustrate our key results"
-  },
   "M9Jejl": {
     "defaultMessage": "Painel | bud",
     "description": "The page title that is displayed in the browser tab"
@@ -2035,77 +1223,33 @@
     "defaultMessage": "incluiu você como time de apoio em um KR:",
     "description": "This message appears as describe on notification where a user is included on support team of a key-result."
   },
-  "MAcjZG": {
-    "defaultMessage": "Essa ação não pode ser desfeita",
-    "description": "This text is giving more details regarding the delete alert in our drawer"
-  },
-  "mbJq/U": {
-    "defaultMessage": "Tem certeza que deseja excluir o ciclo {period}?",
-    "description": "This message is used as the title in our first dialog while removing a cycle"
-  },
   "MBvlAH": {
     "defaultMessage": "conta desativada",
     "description": "This string is used to select the not-active cycles option."
-  },
-  "mdG+CG": {
-    "defaultMessage": "Ciclos ativos",
-    "description": "This text is displayed as a tab where the user can click to change the view below it"
-  },
-  "Me1wRC": {
-    "defaultMessage": "Notificações",
-    "description": "This message appears as the title of the Notifications option in the notifications modal."
-  },
-  "mfowjk": {
-    "defaultMessage": "Um ícone de uma estrela, que aparece junto com a pergunta sobre as principais conquistas que o usuário teve na semana.",
-    "description": "The alternative text explaining our graphic icon"
-  },
-  "MgJJAJ": {
-    "defaultMessage": "Comente aqui! Para marcar alguém, use @ :)",
-    "description": "This text is displayed in our comment input in our key result drawers when it has no value"
   },
   "MHv/ZI": {
     "defaultMessage": "Este time não possui membros",
     "description": "This message is displayed when there is no users in a given team"
   },
-  "minQA9": {
-    "defaultMessage": "Redefinir senha",
-    "description": "This message is the description of the option to alter password of a user."
-  },
   "MIYGie": {
     "defaultMessage": "Seta para direita",
     "description": "The description of the arrow icon."
-  },
-  "mK9HFR": {
-    "defaultMessage": "Dia de fim do período anual",
-    "description": "The label of the company yearly date end while creating a new workspace"
-  },
-  "mkTrvf": {
-    "defaultMessage": "Um ícone de pause, que aparece junto com a pergunta de se o usuario tem alguma barreira.",
-    "description": "The alternative text explaining our graphic icon"
-  },
-  "mkxm93": {
-    "defaultMessage": "Bud é uma plataforma para gerenciamento de OKRs.",
-    "description": "The default description for our page head meta description value"
   },
   "MNn3/r": {
     "defaultMessage": "Insira uma descrição clicando aqui",
     "description": "This text is displayed as a placeholder for the description section of a key-result, only when that key-result don't have a description"
   },
-  "mnors5": {
-    "defaultMessage": "Sobre {nickname}",
-    "description": "The about section title for the user in the user card"
+  "Me1wRC": {
+    "defaultMessage": "Notificações",
+    "description": "This message appears as the title of the Notifications option in the notifications modal."
+  },
+  "MgJJAJ": {
+    "defaultMessage": "Comente aqui! Para marcar alguém, use @ :)",
+    "description": "This text is displayed in our comment input in our key result drawers when it has no value"
   },
   "MpjjOt": {
     "defaultMessage": "Bud",
     "description": "The default title for our page head meta title value"
-  },
-  "mXb4/b": {
-    "defaultMessage": "Configurações | bud",
-    "description": "The page title that is displayed in the browser tab for the settings page"
-  },
-  "mxk1xU": {
-    "defaultMessage": "Ative os lembretes para essa rotina!",
-    "description": "Routine notification settings modal title"
   },
   "MyqmeF": {
     "defaultMessage": "Não foi possível criar o ciclo.",
@@ -2119,37 +1263,17 @@
     "defaultMessage": "Responder",
     "description": "Button to Reply routine on the teams page."
   },
-  "n3PYQR": {
-    "defaultMessage": "Escreva sobre {isMyUser, select, true {você} other {{gender, select, MALE {o} FEMALE {a} other {o}} {firstName}}}",
-    "description": "This is the fallback value that goes on our user account settings page, at the seventh field to update the user informations. The fallback value appears if the user has no data at that field"
-  },
   "N70n39": {
     "defaultMessage": "Progresso individual com base na média dos resultados-chave deste trimestre",
     "description": "Quarterly progress chart tooltip message"
-  },
-  "n8OKn4": {
-    "defaultMessage": "Resultados-chave",
-    "description": "The title of the second section of My Week notification tab."
   },
   "N8Xs+4": {
     "defaultMessage": "EXCLUIR",
     "description": "This message is used as a keyword to remove a given objective"
   },
-  "na6BgW": {
-    "defaultMessage": "Histórico",
-    "description": "History, historic, archived items"
-  },
   "NADPP1": {
     "defaultMessage": "Um ícone de lata de lixo",
     "description": "The desc message for the Delete icon. This icon is used to ilustrate our key results"
-  },
-  "Nafqgw": {
-    "defaultMessage": "Cancelar check-in",
-    "description": "This message is displayed as a label button when the check-in form is opened in our key result section"
-  },
-  "NaLzV2": {
-    "defaultMessage": "Um botão que ao ser clicado direciona o usuário para a questão seguinte no formulário de rotinas.",
-    "description": "This message is the description of a button icon that, when clicked, directs the user to the next question in the routines form."
   },
   "NAsOFG": {
     "defaultMessage": "Um ícone de seta. Ao clicar você abrirá o gráfico de progress",
@@ -2159,85 +1283,33 @@
     "defaultMessage": "Uma seta para cima. Ao clicar nela você fechará o menu de seleção",
     "description": "This is the desc attribute of our chevron up icon. It is used by screen readers"
   },
-  "ndABHM": {
-    "defaultMessage": "Admin",
-    "description": "This string is used to select the user admin role."
-  },
-  "nEQaGP": {
-    "defaultMessage": "OKRs Trimestrais {quarter}",
-    "description": "The summery title for the quarterly OKRs"
-  },
-  "nfdvr1": {
-    "defaultMessage": "Esperado",
-    "description": "This message is displayed in the chart tooltip of our key-result sidebar"
-  },
-  "nJ7CuJ": {
-    "defaultMessage": "Um ícone de relógio",
-    "description": "The desc message for the TimesSquare icon. This icon is used to ilustrate our key results"
-  },
   "NMWZmv": {
     "defaultMessage": "Este campo precisa conter algum valor",
     "description": "This text is used inside the update objective fields when the user tries to make blank a given required field"
-  },
-  "nnWr7M": {
-    "defaultMessage": "Gênero",
-    "description": "This is the label that goes on our user account settings page, at the sixth field to update the user informations"
-  },
-  "NojznG": {
-    "defaultMessage": "Subtimes {isLoaded, select, true {({totalTeamsCount})} other{}}",
-    "description": "This message is displayed inside the explore page, above the child teams section"
   },
   "NOqI9i": {
     "defaultMessage": "Como está sua confiança?",
     "description": "This is the label of the check-in form that indicates to which confidence level the user would update her/his key result"
   },
-  "nPCTf0": {
-    "defaultMessage": "Redes sociais",
-    "description": "This title is displayed as the heading of the social media section in our user account settings page"
-  },
-  "nPjrcU": {
-    "defaultMessage": "Editar",
-    "description": "This message is displayer as soon as our user hovers the avatar"
-  },
-  "NPR3JP": {
-    "defaultMessage": "PLANO INDIVIDUAL",
-    "description": "This message is displayed above the empty state inside the active cycles section at the User page"
-  },
-  "npWxt7": {
-    "defaultMessage": "Um botão com um ícone de X. Ao clicar nele você irá cancelar a atualização do objetivo",
-    "description": "This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the cancel button"
-  },
-  "nqlxOI": {
-    "defaultMessage": "Você está em dia com seus compromissos no Bud.",
-    "description": "The page description that is displayed if the user has no key result in the this week notifications tab."
-  },
-  "nriJkh": {
-    "defaultMessage": "Sim!",
-    "description": "This message appears when the user has a blockage during the week."
-  },
-  "nrToz/": {
-    "defaultMessage": "Voltar",
-    "description": "This message is displayed as a label in the button on our unknown error page"
-  },
-  "Nwj8qY": {
-    "defaultMessage": "Minha conta",
-    "description": "MainAppBar user menu first item option"
-  },
-  "nWz8Nt": {
-    "defaultMessage": "Neutro",
-    "description": "The neutral gender for the company while creating a new workspace"
-  },
-  "Ny2Pia": {
-    "defaultMessage": "Ciclos são os horizontes de tempo definidos para a estratégia.{breakingline}Recomendamos a criação de um ciclo anual para a empresa e um ciclo trimestral para os times.",
-    "description": "The description page."
-  },
   "NYGW+N": {
     "defaultMessage": "Cargo",
     "description": "This is the label that goes on our user account settings page, at the fifth field to update the user informations"
   },
-  "O0072X": {
-    "defaultMessage": "Um desenho de fantasma, indicando que este resultado-chave não tem nenhum card de atividade",
-    "description": "This text is used by screen readers to explain our ghost image inside our key result drawer"
+  "NaLzV2": {
+    "defaultMessage": "Um botão que ao ser clicado direciona o usuário para a questão seguinte no formulário de rotinas.",
+    "description": "This message is the description of a button icon that, when clicked, directs the user to the next question in the routines form."
+  },
+  "Nafqgw": {
+    "defaultMessage": "Cancelar check-in",
+    "description": "This message is displayed as a label button when the check-in form is opened in our key result section"
+  },
+  "NojznG": {
+    "defaultMessage": "Subtimes {isLoaded, select, true {({totalTeamsCount})} other{}}",
+    "description": "This message is displayed inside the explore page, above the child teams section"
+  },
+  "Ny2Pia": {
+    "defaultMessage": "Ciclos são os horizontes de tempo definidos para a estratégia.{breakingline}Recomendamos a criação de um ciclo anual para a empresa e um ciclo trimestral para os times.",
+    "description": "The description page."
   },
   "O13rH5": {
     "defaultMessage": "{completed}/{total}",
@@ -2247,49 +1319,33 @@
     "defaultMessage": "Progresso",
     "description": "The title of the progress section in our key-result sidebar"
   },
-  "ObFHxY": {
-    "defaultMessage": "Cancelar",
-    "description": "This text appears as a browser tooltip above the icon. This icon appears below an EditableTextArea. It is used to cancel the edition of that field"
+  "OEPd1+": {
+    "defaultMessage": "Essas foram as suas notificações recentes!",
+    "description": "This message appears when no more notifications to listing."
   },
   "OEfoTC": {
     "defaultMessage": "Um ícone de setas entrelaçadas. Ao clicar aqui você irá editar esse campo",
     "description": "This message is used by screen readers when the user is focusing on the component which contains the user name and picture. This component is used in multiple places, like: our header, the key-result drawers, and other"
   },
-  "OEPd1+": {
-    "defaultMessage": "Essas foram as suas notificações recentes!",
-    "description": "This message appears when no more notifications to listing."
-  },
   "OErdYA": {
     "defaultMessage": "Um ícone de tres pontos, indicando que ao clicar aqui um menu se expandirá",
     "description": "The description for screen readers regarding the three dots above the objectives accordion"
-  },
-  "oGyXN5": {
-    "defaultMessage": "Colegas com plano individual",
-    "description": "Friends with individual OKRs title"
-  },
-  "oh+3Gh": {
-    "defaultMessage": "Anual",
-    "description": "This option makes an cycle with yearly cadence"
   },
   "OMUZ7w": {
     "defaultMessage": "Feminino",
     "description": "The female gender for the company while creating a new workspace"
   },
-  "ooNWJL": {
-    "defaultMessage": "Adicionar Time de Apoio",
-    "description": "The label text for the add button icon in our key result single page or drawers"
+  "OS8mCA": {
+    "defaultMessage": "Cadência",
+    "description": "The description for cadence cycle field"
   },
-  "or8fId": {
-    "defaultMessage": "Voltar",
-    "description": "This message is displayed as a label in the button on our not found error page"
+  "ObFHxY": {
+    "defaultMessage": "Cancelar",
+    "description": "This text appears as a browser tooltip above the icon. This icon appears below an EditableTextArea. It is used to cancel the edition of that field"
   },
   "OrqJud": {
     "defaultMessage": "Um ícone de coroa que indica o líder do time",
     "description": "The crown icon description"
-  },
-  "OS8mCA": {
-    "defaultMessage": "Cadência",
-    "description": "The description for cadence cycle field"
   },
   "OwHPoA": {
     "defaultMessage": "Ainda não foram criados OKRs neste Plano Individual",
@@ -2298,10 +1354,6 @@
   "OwWiN7": {
     "defaultMessage": "Criar novo usuário",
     "description": "This message appears as an option in the team page while adding a new user"
-  },
-  "oycX/u": {
-    "defaultMessage": "Essa semana",
-    "description": "The text displayed as a prefix in our progress tag label in the team objective accordion button"
   },
   "P+AGjw": {
     "defaultMessage": "Como está o progresso dos times?",
@@ -2315,101 +1367,41 @@
     "defaultMessage": "Dia de início do período anual",
     "description": "The label of the company yearly date start while creating a new workspace"
   },
-  "P0ljMC": {
-    "defaultMessage": "Média do progresso de todos os seus resultados-chave no ciclo trimestral atual",
-    "description": "Quarterly progress chart tooltip message"
-  },
-  "p2UjMZ": {
-    "defaultMessage": "Minhas Coisas | bud",
-    "description": "The page title that is displayed in the browser tab"
-  },
-  "pAXjHu": {
-    "defaultMessage": "Retrospectiva",
-    "description": "This is the title of the retrospectives tab on the team page."
-  },
-  "Pb0Tht": {
-    "defaultMessage": "Sobre este check-in",
-    "description": "This text is displayed in our check-in card, above the user comment if it exists"
-  },
-  "pB9cMu": {
-    "defaultMessage": "Não",
-    "description": "This message appears as a description of the second option."
-  },
-  "pbBzqW": {
-    "defaultMessage": "Lembrete ativo",
-    "description": "Message displayed when the routine notifications are active."
-  },
-  "pbVToL": {
-    "defaultMessage": "Criar um usuário",
-    "description": "This message appears as a button when a team has no members yet"
-  },
-  "Pf0TwP": {
-    "defaultMessage": "Excluir objetivo",
-    "description": "This message is used in the confirmation button while removing a given objective"
-  },
   "PFysOr": {
     "defaultMessage": "Uma seta para baixo. Ela indica que ao clicar aqui você irá editar a meta deste resultado-chave",
     "description": "This message is displayed for screen readers as the description of the arrow down icon inside the key-result drawers. That icon is only displayed when the user hovers the mouse over the goal"
-  },
-  "piM/9+": {
-    "defaultMessage": "Explore este objetivo completo no Plano Individual de {user}",
-    "description": "This message appears in the individual objective tooltip"
-  },
-  "Pkdkh4": {
-    "defaultMessage": "Minhas Key Result",
-    "description": "The name of the Key Results page, located at \"/keyResults\""
   },
   "PKRdQG": {
     "defaultMessage": "Enviar",
     "description": "This message appears in the button to send routine form answers."
   },
-  "PktsGq": {
-    "defaultMessage": "Check-list",
-    "description": "This is the title of our checklist section inside the key-result sidebar"
-  },
-  "pLYuso": {
-    "defaultMessage": "Um ícone de caneta. Ao clicar nele você irá editar esse campo",
-    "description": "The description for our pen icon. This message is used by screen readers to improve our accesibility"
-  },
-  "pmuG/e": {
-    "defaultMessage": "Líder",
-    "description": "This string is used to select the user edit role."
-  },
-  "poN086": {
-    "defaultMessage": "Um ícone circular, com bordas e um símbolo de mais ao centro",
-    "description": "This is the desc text that is displayed for screen readers"
-  },
-  "pQnPZP": {
-    "defaultMessage": "Ciclo pai",
-    "description": "The description for parent cycle field"
-  },
   "PSCS+h": {
     "defaultMessage": "Nome",
     "description": "The label of the first name field in the create user form"
+  },
+  "PYLIcI": {
+    "defaultMessage": "Meta",
+    "description": "This message is displayed below the goal thumb"
+  },
+  "Pf0TwP": {
+    "defaultMessage": "Excluir objetivo",
+    "description": "This message is used in the confirmation button while removing a given objective"
+  },
+  "Pkdkh4": {
+    "defaultMessage": "Minhas Key Result",
+    "description": "The name of the Key Results page, located at \"/keyResults\""
+  },
+  "PktsGq": {
+    "defaultMessage": "Check-list",
+    "description": "This is the title of our checklist section inside the key-result sidebar"
   },
   "PtUosx": {
     "defaultMessage": "Masculino",
     "description": "The user gender male option while creating a new workspace"
   },
-  "pTXAs1": {
-    "defaultMessage": "Um ícone de seta para a direita. Ao clicar aqui voce será enviado para a página deste time",
-    "description": "This message is used by screen readers to explain the right arrow at our team lists component"
-  },
-  "pVkTLM": {
-    "defaultMessage": "Um ícone de coroa",
-    "description": "The desc message for the crown icon. This icon is used to ilustrate when a team card is actually a company"
-  },
-  "pXeDLf": {
-    "defaultMessage": "Sobrenome",
-    "description": "This is the label that goes on our user account settings page, at the second field to update the user informations"
-  },
   "PxWBQZ": {
     "defaultMessage": "Cargo",
     "description": "The label of the role field in the create user form"
-  },
-  "PYLIcI": {
-    "defaultMessage": "Meta",
-    "description": "This message is displayed below the goal thumb"
   },
   "Q+5Uuc": {
     "defaultMessage": "Português",
@@ -2427,37 +1419,17 @@
     "defaultMessage": "custom emoji with neutral expression",
     "description": "This message is used as a description of emoji feeling 3"
   },
-  "QcCy51": {
-    "defaultMessage": "Valor atual",
-    "description": "This tooltip is displayed when the user hovers the left side value of our progress bar"
-  },
-  "QcWe3c": {
-    "defaultMessage": "Um ícone de gráfico que aparece ao lado da lista de histórico de respostas de um usuário.",
-    "description": "The alternative text explaining our graphic icon"
-  },
   "QEsnT8": {
     "defaultMessage": "Percentual de progresso entre o valor inicial e a meta",
     "description": "This tooltip explains the fifth column of the key result list"
-  },
-  "qGLpBy": {
-    "defaultMessage": "Date de início",
-    "description": "The description for date-start cycle field"
-  },
-  "qhchMM": {
-    "defaultMessage": "Representam as mais altas prioridades e comunicam essa direção com bastante clareza.",
-    "description": "This card guides the creation of Objectives."
-  },
-  "QKkwxU": {
-    "defaultMessage": "Ações",
-    "description": "This message is displayed as the column header for the key-result table in the actions column"
   },
   "QKUmFp": {
     "defaultMessage": "Fechar",
     "description": "This message is displayed when an user hovers the close button of our progress slider popover"
   },
-  "ql0LOi": {
-    "defaultMessage": "Procurar pessoas",
-    "description": "This message appears as a label in users search input."
+  "QKkwxU": {
+    "defaultMessage": "Ações",
+    "description": "This message is displayed as the column header for the key-result table in the actions column"
   },
   "QMM2q6": {
     "defaultMessage": "Área",
@@ -2471,21 +1443,9 @@
     "defaultMessage": "Lembretes de Rotina",
     "description": "Routine notification settings description title"
   },
-  "qp4Qmm": {
-    "defaultMessage": "Ir para o perfil de {username}",
-    "description": "This button redirects to the selected user."
-  },
   "QPGUqB": {
     "defaultMessage": "Alta Confiança",
     "description": "We use this tag to group every key result with confidence higher than 66"
-  },
-  "QpkwoM": {
-    "defaultMessage": "Tem certeza que deseja excluir este objetivo?",
-    "description": "This message is used as the first dialog title while removing an objective"
-  },
-  "qrgfik": {
-    "defaultMessage": "Em uma frase, qual é a missão deste time?",
-    "description": "The placeholder to the description field in team add/edit modal"
   },
   "QRn560": {
     "defaultMessage": "Progresso",
@@ -2495,29 +1455,25 @@
     "defaultMessage": "Um novo objetivo foi criado com sucesso",
     "description": "This message appears as a toast as soon as the the user clicks to add a new objective in the team page"
   },
-  "qsn7TW": {
-    "defaultMessage": "Adicionar nova tarefa pessoal",
-    "description": "The add new personal task button label"
+  "QcCy51": {
+    "defaultMessage": "Valor atual",
+    "description": "This tooltip is displayed when the user hovers the left side value of our progress bar"
+  },
+  "QcWe3c": {
+    "defaultMessage": "Um ícone de gráfico que aparece ao lado da lista de histórico de respostas de um usuário.",
+    "description": "The alternative text explaining our graphic icon"
+  },
+  "QpkwoM": {
+    "defaultMessage": "Tem certeza que deseja excluir este objetivo?",
+    "description": "This message is used as the first dialog title while removing an objective"
   },
   "Qt52rN": {
     "defaultMessage": "Idioma",
     "description": "This message appears as a label while we are creating a new user"
   },
-  "qYpqgw": {
-    "defaultMessage": "Novo item",
-    "description": "This is the description used as default by a check mark when we add a new item"
-  },
-  "qytqsj": {
-    "defaultMessage": "Trimestral",
-    "description": "This text is used as prefix for our quarterly cadences"
-  },
   "R/9LlP": {
     "defaultMessage": "Objetivos",
     "description": "Title of objectives"
-  },
-  "r1mfc1": {
-    "defaultMessage": "Informações pessoais",
-    "description": "This title is displayed as the heading of the personal informations section in our user account settings page"
   },
   "R5fgoj": {
     "defaultMessage": "Próximo",
@@ -2535,6 +1491,1218 @@
     "defaultMessage": "Este time não possui OKRs",
     "description": "This message is displayed as the empty state message inside the team page"
   },
+  "RN1J2p": {
+    "defaultMessage": "Essa semana",
+    "description": "The title of the third column in our body table at the teams overview report in our dashboard"
+  },
+  "RWaMNF": {
+    "defaultMessage": "Um ícone de coração",
+    "description": "The desc message for the Heart icon. This icon is used to ilustrate our key results"
+  },
+  "RZrZdZ": {
+    "defaultMessage": "Home",
+    "description": "The name of the Home page, located at \"/\""
+  },
+  "RojqOy": {
+    "defaultMessage": "Responder agora",
+    "description": "The text in the button to answer the routine"
+  },
+  "RrW2fc": {
+    "defaultMessage": "Atualize seu cargo",
+    "description": "This is the fallback value that goes on our user account settings page, at the fifth field to update the user informations. The fallback value appears if the user has no data at that field"
+  },
+  "RwKPpx": {
+    "defaultMessage": "EXCLUIR",
+    "description": "This message is used as keyword to delete a key-result"
+  },
+  "S/L2jr": {
+    "defaultMessage": "Sentimento",
+    "description": "The title of the feeling chart"
+  },
+  "S9cIsW": {
+    "defaultMessage": "Editar time",
+    "description": "The text is displayed as a heading in the add team modal"
+  },
+  "SDzYq9": {
+    "defaultMessage": "Desculpe, mas houve um erro inesperado. Tente novamente mais tarde",
+    "description": "This message appears when the user tries to remove a given objective, but receives an error"
+  },
+  "SE9cO0": {
+    "defaultMessage": "Editar time",
+    "description": "Team edit button label"
+  },
+  "SK6+Sz": {
+    "defaultMessage": "Visão geral dos times",
+    "description": "The title of the teams overview"
+  },
+  "SL45P4": {
+    "defaultMessage": "Gênero",
+    "description": "The label of the gender field in the create user form"
+  },
+  "SRIfUY": {
+    "defaultMessage": "Time",
+    "description": "The label of the team field in the create user form"
+  },
+  "SU+pQ8": {
+    "defaultMessage": "Clique no botão <span>...</span> para criar o primeiro resultado-chave deste objetivo.",
+    "description": "This message is displayed in the key-results empty state inside the team page when an objective has no key-results"
+  },
+  "SWl7UB": {
+    "defaultMessage": "Um ícone de \"x\". Ao clicar nele você fechará o box de atualização de progresso",
+    "description": "This description is used for accessibility. Screen readers uses it when they hover the close icon button in our progress slider popover close button"
+  },
+  "Sau4Na": {
+    "defaultMessage": "Nome",
+    "description": "The user first name input placeholder while creating a new workspace"
+  },
+  "Sb6dkV": {
+    "defaultMessage": "Ver detalhes",
+    "description": "This option will show a sidebar with the details of the selected user."
+  },
+  "SdgM/R": {
+    "defaultMessage": "Minha conta",
+    "description": "This title is displayed as the heading of the definitions menu section"
+  },
+  "SenoB2": {
+    "defaultMessage": "A página que você está procurando não foi encontrada!",
+    "description": "The title displayed in our not found error page"
+  },
+  "ShzOP9": {
+    "defaultMessage": "Ícone de histórico",
+    "description": "Icon description for history icon"
+  },
+  "SiJuyU": {
+    "defaultMessage": "Um ícone de calendário, indicando que aqui você seleciona o ano que deseja filtrar",
+    "description": "This message is used by screen readers to explain the icon to the user"
+  },
+  "Sm4xi7": {
+    "defaultMessage": "Máquina do tempo",
+    "description": "This message is displayed as the title of the time machine section in a team's page"
+  },
+  "Smwz9L": {
+    "defaultMessage": "Descreve o período no qual esse resultado-chave faz parte",
+    "description": "This tooltip explains the sixth column of the key result list"
+  },
+  "Sn7K6v": {
+    "defaultMessage": "Um ícone de sino, ao clicar nele você verá suas notificações",
+    "description": "The alternative text explaining our notification bell icon"
+  },
+  "SpAXmO": {
+    "defaultMessage": "Um ícone de calendário. Ele indica que nesse campo fica o prazo do objetivo",
+    "description": "The alternative text explaining our calendar icon in the objective accordion item"
+  },
+  "SrOZ1m": {
+    "defaultMessage": "Criar usuário",
+    "description": "The sidebar title on our create user sidebar"
+  },
+  "SsQRcF": {
+    "defaultMessage": "Uma seta que ao ser clicada expande a checklist deste resultado-chave",
+    "description": "This message is used by screen readers to explain the collapse icon in our key-result sidebar on the checklist section"
+  },
+  "SxsVDt": {
+    "defaultMessage": "Meta",
+    "description": "This is the label of the check-in form that indicates the goal for her/his key result"
+  },
+  "T5iKmP": {
+    "defaultMessage": "{prefix} {cycle} {suffix}",
+    "description": "This message displays the cycle name with a given prefix"
+  },
+  "TCJuuU": {
+    "defaultMessage": "Selecione ao menos um membro para completar a ação.",
+    "description": "This message appears as an error Toast when a user tries to add members to a team without selecting at least one."
+  },
+  "TGP9cN": {
+    "defaultMessage": "Salvar",
+    "description": "The button to create or edit a cycle on modal"
+  },
+  "TIorHN": {
+    "defaultMessage": "Existe um risco de não alcançarmos o resultado-chave, mas seguimos otimistas",
+    "description": "This text explains our tag to the user"
+  },
+  "TN6PhK": {
+    "defaultMessage": "Meu perfil",
+    "description": "MainAppBar user menu first item option"
+  },
+  "TYmE01": {
+    "defaultMessage": "Progresso atual",
+    "description": "This tooltip is displayed when the user hovers the percentage progress above the bar"
+  },
+  "TaXVmY": {
+    "defaultMessage": "Adicionar um OKR neste ciclo",
+    "description": "This message is displayed inside the team page, on the options menu of a cycle"
+  },
+  "TzHlPJ": {
+    "defaultMessage": "Em manutenção | bud",
+    "description": "The page title of our under maintenance error page that is displayed in the browser tab"
+  },
+  "U1tYhb": {
+    "defaultMessage": "Adicionar",
+    "description": "The label text for the add button in our key result single page or drawers"
+  },
+  "U2EgRG": {
+    "defaultMessage": "Explorar | bud",
+    "description": "The page title that is displayed in the browser tab"
+  },
+  "UBruoq": {
+    "defaultMessage": "Um ícone de com diversas superfícies, uma em cima da outra",
+    "description": "The alternative text explaining our stack icon"
+  },
+  "UHZQHg": {
+    "defaultMessage": "Respostas",
+    "description": "This message appears in the subtitle of the menu that allows users to browse responses through the history."
+  },
+  "UNfjU2": {
+    "defaultMessage": "desativado",
+    "description": "This message appears when we have successfully activate/deactivate a cycle."
+  },
+  "UU1FXI": {
+    "defaultMessage": "Vincula o ciclo trimestral ao ciclo anual ao qual ele pertence.",
+    "description": "This message appears on tooltip that explain the parent cycle select field."
+  },
+  "UUo+Pt": {
+    "defaultMessage": "Este time é uma empresa",
+    "description": "The title message for the crown icon. This icon is used to ilustrate when a team card is actually a company"
+  },
+  "UYwpSr": {
+    "defaultMessage": "Time",
+    "description": "This message is displayed as the column header for the key-result table in the team column"
+  },
+  "UZnhGI": {
+    "defaultMessage": "Passo 1",
+    "description": "The label of the first step while creating a new workspace"
+  },
+  "Ua7Hgq": {
+    "defaultMessage": "Voltar",
+    "description": "Return to overview page icon description"
+  },
+  "UozvhV": {
+    "defaultMessage": "Usuários",
+    "description": "This label defines the text on the first menu section option"
+  },
+  "Uu0OJV": {
+    "defaultMessage": "Um ícone de imagem. Ele indica que nesse campo fica seu avatar",
+    "description": "The alternative text explaining our image icon in the settings account page"
+  },
+  "VBdX86": {
+    "defaultMessage": "{username} ainda não tem nenhuma tarefa em seu nome nos OKRs da empresa.",
+    "description": "The empty state message header when a user have no tasks"
+  },
+  "VDLkuO": {
+    "defaultMessage": "Mostrar mais",
+    "description": "This text is displayed in the button that expands a truncated text"
+  },
+  "VFj8OD": {
+    "defaultMessage": "Título copiado com sucesso.",
+    "description": "This message appears in the toast when you successfully copies the title of the key result"
+  },
+  "VHOea1": {
+    "defaultMessage": "Excluir resultado-chave",
+    "description": "This message is used as the label in the confirmation button while removing a key-result"
+  },
+  "VLU792": {
+    "defaultMessage": "Check-in",
+    "description": "The title of the button to create a check-in in the check-in notifications tab, when clicked it opens the key result drawer."
+  },
+  "VNHZWm": {
+    "defaultMessage": "Período",
+    "description": "The name label. It is displayed in the Cycle section, as a label of the name property"
+  },
+  "VPJIpc": {
+    "defaultMessage": "OKRs",
+    "description": "This message is displayed above the empty state inside the active cycles section at the User page"
+  },
+  "VSS4F8": {
+    "defaultMessage": "{unit, select, fallback {desde {date}} other {{date}}}",
+    "description": "This text displays the latest report status for a given component, using a given date logic"
+  },
+  "VUKPKt": {
+    "defaultMessage": "Cancelar",
+    "description": "This is a button label displayed inside the insert key-result drawer. This is the first button"
+  },
+  "VW9LHA": {
+    "defaultMessage": "Email de redefinição de senha enviado com sucesso.",
+    "description": "This message appears in a toast after the user ask to reset password."
+  },
+  "VltGNp": {
+    "defaultMessage": "Um desenho de fantasma, indicando que este resultado-chave não tem nenhum card de atividade",
+    "description": "This text is used by screen readers to explain our ghost image inside our key result drawers"
+  },
+  "Vytr8A": {
+    "defaultMessage": "Editar ciclo",
+    "description": "The title for cycle modal"
+  },
+  "W/yMJH": {
+    "defaultMessage": "Financeiro (Libra)",
+    "description": "This message is displayed inside our key-result format select as the title of the coin GBP format"
+  },
+  "W37c+K": {
+    "defaultMessage": "Um ícone de check. Ele representa a quantidade de itens marcados como completo em sua checklist",
+    "description": "This text is used by screen readers to explain the check icon in our key-result drawer checklist section"
+  },
+  "W9swHV": {
+    "defaultMessage": "Configurações",
+    "description": "This tooltip is displayed when the user hovers the settings icon"
+  },
+  "WEXvlm": {
+    "defaultMessage": "Experimente usar esse espaço para listar suas prioridades do dia, por exemplo :)",
+    "description": "Personal tasks empty state sub title"
+  },
+  "WIR0FJ": {
+    "defaultMessage": "Masculino",
+    "description": "The male gender for the company while creating a new workspace"
+  },
+  "WKevJy": {
+    "defaultMessage": "Clique aqui para editar esse campo",
+    "description": "The title for our pen icon. This message is displayed in our UI as a tooltip"
+  },
+  "WR43/0": {
+    "defaultMessage": "Você ainda não tem nenhuma tarefa.",
+    "description": "The empty state message header when you have no tasks"
+  },
+  "Wa22G2": {
+    "defaultMessage": "Média confiança",
+    "description": "Title of medium confidence health strategy"
+  },
+  "WiYOXK": {
+    "defaultMessage": "Valor Inicial",
+    "description": "This label appears above the fourth input in our insert key-result drawer"
+  },
+  "Wk0KQD": {
+    "defaultMessage": "Lembrete inativo",
+    "description": "Message displayed when the routine notifications are inactive."
+  },
+  "WkvrVY": {
+    "defaultMessage": "Procurar times",
+    "description": "The text is displayed as a placeholder in any search input regarding teams"
+  },
+  "Ww/cjH": {
+    "defaultMessage": "Com Barreira",
+    "description": "The title of the with barrier chart"
+  },
+  "X+heBq": {
+    "defaultMessage": "Routine notification settings button",
+    "description": "Label for routine notification settings button"
+  },
+  "X2V7x7": {
+    "defaultMessage": "Confiança",
+    "description": "The text of the table head related to the Confidence Level column"
+  },
+  "XCDzMo": {
+    "defaultMessage": "Botão de opções",
+    "description": "This button allows you to choose an option that can allow you to copy the title ou exclude the KR."
+  },
+  "XENgso": {
+    "defaultMessage": "Médio",
+    "description": "We use this tag to group every key result with confidence higher than 33 but lower than 66"
+  },
+  "XEey8C": {
+    "defaultMessage": "Arraste até o novo valor para iniciar um check-in",
+    "description": "This tooltip is displayed when the user hovers the thumb of our progress bar"
+  },
+  "XN0ZEi": {
+    "defaultMessage": "Passo 2",
+    "description": "The label of the second step while creating a new workspace"
+  },
+  "XNkzYe": {
+    "defaultMessage": "Um ícone de pin de localização",
+    "description": "The desc message for the Location icon. This icon is used to ilustrate our key results"
+  },
+  "XOLhDn": {
+    "defaultMessage": "Adicionar",
+    "description": "This message appears on the add a user to the team button when the team is empty."
+  },
+  "XYg5xf": {
+    "defaultMessage": "Clique aqui para editar suas configurações",
+    "description": "The title text of our settings icon, it is displayed when an user hover the icon itself"
+  },
+  "XZF51J": {
+    "defaultMessage": "Uma imagem que representa a ausência de novas notificações.",
+    "description": "The alternative text explain the empty state message when no more notifications to listing."
+  },
+  "XZcPVc": {
+    "defaultMessage": "Uma mulher analisando gráficos e apontando com um dedo.",
+    "description": "The alternative text explaining the empty item image"
+  },
+  "XbzHtU": {
+    "defaultMessage": "custom emoji with smile on face",
+    "description": "This message is used as a description of emoji feeling 5"
+  },
+  "Xcxvrr": {
+    "defaultMessage": "A calendar icon",
+    "description": "The description of the calendar icon at the routine notification component."
+  },
+  "XiSFEr": {
+    "defaultMessage": "Erro inesperado | bud",
+    "description": "The page title of our unknown error page that is displayed in the browser tab"
+  },
+  "XvdEsU": {
+    "defaultMessage": "Um ícone de tres pontos, indicando que ao clicar aqui um menu se expandirá",
+    "description": "The description for screen readers regarding the three dots icon in the objectives accordion"
+  },
+  "XyhQJo": {
+    "defaultMessage": "O ciclo foi removido com sucesso",
+    "description": "This message appears in a toast after the user removes a cycle"
+  },
+  "Y+MtZe": {
+    "defaultMessage": "Nome",
+    "description": "This is the label that goes on our user account settings page, at the first field to update the user informations"
+  },
+  "Y1oyYG": {
+    "defaultMessage": "Um ícone de seta para cima, indicando que o progresso aumentou",
+    "description": "This desc message explains the increase icon for screen readers"
+  },
+  "Y8TWo2": {
+    "defaultMessage": "Plano Individual",
+    "description": "Individual OKR title on the navigation tab"
+  },
+  "YFb9UA": {
+    "defaultMessage": "Ir para o perfil",
+    "description": "This option will redirect the user to the selected user profile."
+  },
+  "YUvWwS": {
+    "defaultMessage": "Registro",
+    "description": "It is used as a fallback if the component has no card type defined for it"
+  },
+  "Ykg0Jh": {
+    "defaultMessage": "Realizado por <highlight>{author}</highlight> {unit, select, fallback {em} other {}} {time}",
+    "description": "This text is displayed as a helper text, below the check-in card title"
+  },
+  "YmUBcv": {
+    "defaultMessage": "Editar time",
+    "description": "The tooltip on the gear icon that edits the team"
+  },
+  "YxNkP6": {
+    "defaultMessage": "Check-in",
+    "description": "This text is displayed in some places in our timeline card, showing the type of the card in a friendly name"
+  },
+  "YzN13f": {
+    "defaultMessage": "Um ícone de um alvo, indicando que essa é a meta do seu resultado-chave",
+    "description": "The description text for the key-result section goal icon"
+  },
+  "YznDPX": {
+    "defaultMessage": "Resultado-chave criado com sucesso!",
+    "description": "This message appears after the user creates a new key-result as a toast"
+  },
+  "Z9w45E": {
+    "defaultMessage": "Usuários com essa permissão podem editar e fazer check-in apenas dos resultados-chave que fazem parte.",
+    "description": "This string is used to describe the user default role selection."
+  },
+  "ZCWI2f": {
+    "defaultMessage": "Criar novo ciclo",
+    "description": "The title for cycle modal"
+  },
+  "ZMT2Ze": {
+    "defaultMessage": "Criar novo Resultado-Chave",
+    "description": "This is the first option that appears when you open the menu of a given objective inside the accordion button"
+  },
+  "ZPSK4M": {
+    "defaultMessage": "Insira um título para este Resultado-chave",
+    "description": "The placeholder for the first input in our key-result insert drawer form"
+  },
+  "ZVTdlV": {
+    "defaultMessage": "Um ícone de ingresso de cinema",
+    "description": "The desc message for the TicketStar icon. This icon is used to ilustrate our key results"
+  },
+  "ZXpNJ2": {
+    "defaultMessage": "Um ícone de gráfico de pizza",
+    "description": "The desc message for the Graph icon. This icon is used to ilustrate our key results"
+  },
+  "ZkqTBK": {
+    "defaultMessage": "ADICIONAR",
+    "description": "This button is used to add selected members to a team."
+  },
+  "ZmSQ0o": {
+    "defaultMessage": "Você ainda não respondeu essa semana.",
+    "description": "The text that appears at the bottom of the answer component if you didn't answer the routine yet"
+  },
+  "Zmffm0": {
+    "defaultMessage": "Fechar",
+    "description": "This message is displayed as the title text for our close icon in our check-in form"
+  },
+  "Zmw2VE": {
+    "defaultMessage": "Usuários",
+    "description": "The subtitle page."
+  },
+  "Zn0eYa": {
+    "defaultMessage": "Um desenho de uma mulher e um homem, cada qual segurando um pedaço de um quebra-cabeça e colaborando para montá-lo",
+    "description": "The alternative text explaining our team at work image"
+  },
+  "ZvutBL": {
+    "defaultMessage": "Cadência",
+    "description": "This message is displayed as the column header for the cycles table in the cadence column"
+  },
+  "a7sp2+": {
+    "defaultMessage": "Sim",
+    "description": "This message appears as a description of the first option."
+  },
+  "a8O2l+": {
+    "defaultMessage": "Um ícone com o sinal de \"mais\". Ao clicar aqui você irá abrir o menu para inserir um novo usuário",
+    "description": "This message is used in our new user button while seeing the user list"
+  },
+  "aIGly+": {
+    "defaultMessage": "Gênero",
+    "description": "The company gender input placeholder while creating a new workspace"
+  },
+  "aKyktL": {
+    "defaultMessage": "Q2",
+    "description": "This button appears as an empty state while the user is selecting the cycle filter"
+  },
+  "aO+w74": {
+    "defaultMessage": "A confiança mudou neste check-in:",
+    "description": "This text is the first line of our icon tooltip when the check-in has a different confidence from the previous check-in"
+  },
+  "aVLR+w": {
+    "defaultMessage": "100%",
+    "description": "This message is displayed inside our key-result format select as the example of the percent format"
+  },
+  "acrz2t": {
+    "defaultMessage": "Cancelar",
+    "description": "The label of the cancel button of the create user form"
+  },
+  "agEavf": {
+    "defaultMessage": "Comente o que {user} compartilhou!",
+    "description": "This message appears as placeholder of input."
+  },
+  "ah2n1K": {
+    "defaultMessage": "Nome do período trimestral",
+    "description": "The label of the company quarterly period while creating a new workspace"
+  },
+  "atQu7S": {
+    "defaultMessage": "Membro adicionado ao time com sucesso.",
+    "description": "This message appears on a successful toast when we add a user to a team."
+  },
+  "az3ncM": {
+    "defaultMessage": "Atenção!{breakline}Esta ação não pode ser desfeita.",
+    "description": "This message is used as the title in our second dialog while removing a cycle"
+  },
+  "bPInC0": {
+    "defaultMessage": "Editar ciclo",
+    "description": "This message is the description of the edit cycle option."
+  },
+  "bZXWCR": {
+    "defaultMessage": "Padrão",
+    "description": "This string is used to select the user default role."
+  },
+  "bZYEAl": {
+    "defaultMessage": "Um círculo com um sinal de subtração no meio, indicando que o progresso se manteve o mesmo",
+    "description": "This desc message explains the neutral icon for screen readers"
+  },
+  "bdYpnS": {
+    "defaultMessage": "CANCELAR",
+    "description": "This button is used to close the modal to add team members."
+  },
+  "bdkUKs": {
+    "defaultMessage": "Times",
+    "description": "This is the label that goes on our user account settings page, at the fourth field to update the user informations"
+  },
+  "bh8jgN": {
+    "defaultMessage": "novo!",
+    "description": "The text inside the tag to inform new buttons"
+  },
+  "biDODR": {
+    "defaultMessage": "Um ícone de lupa, indicando que este é um campo de busca",
+    "description": "This text is used by screen readers to explain the search icon in all our search inputs"
+  },
+  "bqCVp4": {
+    "defaultMessage": "Clique aqui para começar a escrever um comentário",
+    "description": "This is the title text that is displayed if the user hovers the mouse in it"
+  },
+  "c6ySN2": {
+    "defaultMessage": "Excluir este Objetivo e seus KRs",
+    "description": "This is the third option that appears when you open the menu of a given objective inside the accordion button"
+  },
+  "c8KQhI": {
+    "defaultMessage": "Semana de",
+    "description": "The prefix that appears in our chart tooltip in the key-result sidebar while seeing a quarterly key-result"
+  },
+  "c8UE59": {
+    "defaultMessage": "Um ícone de busca",
+    "description": "The desc message for the Search icon. This icon is used to ilustrate our key results"
+  },
+  "c8x6gV": {
+    "defaultMessage": "Explorar ciclos anteriores",
+    "description": "This message is displayed when the user opens the menu inside a given cycle at the team page"
+  },
+  "cGFQsk": {
+    "defaultMessage": "Desculpe, aconteceu um erro inesperado. Tente novamente mais tarde",
+    "description": "This message appears as an error toast when we have an unknown error while creating a new cycle"
+  },
+  "cRj0sI": {
+    "defaultMessage": "Desculpe, mas houve um erro inesperado. Tente novamente mais tarde",
+    "description": "This message appears when the user tries to remove a given key-result, but receives an error"
+  },
+  "chwy/J": {
+    "defaultMessage": "Responder hoje",
+    "description": "The text that goes in the update text, below the routine title, when the routine is up to date."
+  },
+  "ciNUJf": {
+    "defaultMessage": "Explorar",
+    "description": "MainAppBar menu item that links to teams \"Explore\" page"
+  },
+  "cz6EUM": {
+    "defaultMessage": "Foto",
+    "description": "The label of the picture field in the create user form"
+  },
+  "d62Bt/": {
+    "defaultMessage": "Ícone de um balão de fala",
+    "description": "The description of the thinking balloon icon"
+  },
+  "dB4Sbq": {
+    "defaultMessage": "Calculado pela média do progresso de todos os objetivos de um time e dos “sub-times” abaixo dele",
+    "description": "This tooltip appears when the user hovers the second column title"
+  },
+  "dH7eW3": {
+    "defaultMessage": "Progresso dos Times no {quarter}",
+    "description": "Title to show on the team ranking page when gamification is disabled"
+  },
+  "dLMgRx": {
+    "defaultMessage": "Aperte",
+    "description": "This message appears in the description of the submit the response button in the routines form."
+  },
+  "dbh5MZ": {
+    "defaultMessage": "OKRs {companypreposition} {company}",
+    "description": "Company OKR title of the page"
+  },
+  "dgMLta": {
+    "defaultMessage": "Enviar comentário",
+    "description": "This label is displayed in the submit button in our drawers"
+  },
+  "dlYnI1": {
+    "defaultMessage": "O time de apoio é uma ou mais pessoas que apoiam o responsável em um resultado-chave. No Bud, isso significa",
+    "description": "The message to guide and describe on what is a support team"
+  },
+  "duv/6P": {
+    "defaultMessage": "SENTIMENTO",
+    "description": "The title of the feeling graph"
+  },
+  "dymB9a": {
+    "defaultMessage": "Cada resultado-chave pertence a um objetivo",
+    "description": "This tooltip explains the second column of the key result list"
+  },
+  "e+r00n": {
+    "defaultMessage": "Saiba mais",
+    "description": "A link to a page that talks about the retrospective routine."
+  },
+  "e/i9Ml": {
+    "defaultMessage": "Ícone com três pontos usado em um botão que abre um menu de opções.",
+    "description": "Icon with three dots used on a button that opens an options menu."
+  },
+  "e2FL3I": {
+    "defaultMessage": "Um ícone do sinal de positivo que, ao clicar, irá adicionar um novo item na checklist",
+    "description": "This is used by screen readers to understand the insert new check mark icon in our key-result drawer"
+  },
+  "e37pvj": {
+    "defaultMessage": "Uma seta para baixo, indicando que ao clicar você irá abrir a lista de ciclos",
+    "description": "This message is displayed to the user screen reader when the year select menu is closed"
+  },
+  "e9PG+t": {
+    "defaultMessage": "por {author}",
+    "description": "This message displays the latest report author for a given component"
+  },
+  "eG8Ohg": {
+    "defaultMessage": "OKRs Anuais {year}",
+    "description": "The summary title for the yearly OKRs"
+  },
+  "eI6jYw": {
+    "defaultMessage": "Nenhuma informação",
+    "description": "The fallback value appears if no value is defined for that input. This input is customizable, so it will only appears if no value is defined, and no custom fallback value was provided"
+  },
+  "eQSkLB": {
+    "defaultMessage": "Essa semana",
+    "description": "This message appears with a subtitle in the cad that informs the user feeling status for the current week."
+  },
+  "eUCb55": {
+    "defaultMessage": "Fim",
+    "description": "The label text inside the Cycle section, above the end date in our key result single page or drawers"
+  },
+  "eVsyB5": {
+    "defaultMessage": "Email",
+    "description": "The label of the email field in the create user form"
+  },
+  "eYhGZW": {
+    "defaultMessage": "Nenhuma opção disponível",
+    "description": "This message is displayed when the user tries to list the cycles, but none is defined"
+  },
+  "ej/Q3X": {
+    "defaultMessage": "Cancelar",
+    "description": "The button to close the modal cycle"
+  },
+  "epM1Xt": {
+    "defaultMessage": "Adicionar",
+    "description": "This button is used to create a new cycle."
+  },
+  "f2OulU": {
+    "defaultMessage": "Início",
+    "description": "This message is displayed as the column header for the cycle table in the date start column"
+  },
+  "f6/kwR": {
+    "defaultMessage": "Esse é o progresso acumulado dessa semana",
+    "description": "This tooltip appears when the user hovers the third column title"
+  },
+  "f6KTde": {
+    "defaultMessage": "Ações",
+    "description": "This message is displayed as the column header for the users table in the actions column"
+  },
+  "fFkPeH": {
+    "defaultMessage": "Cargo",
+    "description": "The user role input placeholder while creating a new workspace"
+  },
+  "fI4P80": {
+    "defaultMessage": "Q1",
+    "description": "This button appears as an empty state while the user is selecting the cycle filter"
+  },
+  "fSrztQ": {
+    "defaultMessage": "Compartilhe suas as prioridades, conquistas e barreiras com seu time. Acompanhe e interaja com seus colegas sobre a jornada deles. {link}",
+    "description": "Description of the content of the Retrospective tab on the teams page."
+  },
+  "fVyP58": {
+    "defaultMessage": "Visualize os objetivos e resultados-chave de todos os times dessa área, se aprofunde no detalhamento de progresso, nível de confiança e dono.",
+    "description": "The page description that is displayed in Google and screen readers"
+  },
+  "fYwrtN": {
+    "defaultMessage": "Essa semana",
+    "description": "This message appears with a subtitle in the cad that informs the user productivity status for the current week."
+  },
+  "faL9vf": {
+    "defaultMessage": "Um círculo verde, indicando que a confiança está alta",
+    "description": "A brief explanation for screen readers regarding the green status circle"
+  },
+  "fd6kjy": {
+    "defaultMessage": "Resultado-chave",
+    "description": "The text of the table head related to the KeyResult column"
+  },
+  "ff3h07": {
+    "defaultMessage": "Baixa Confiança",
+    "description": "We use this tag to group every key result with confidence higher than 33 but lower than 66"
+  },
+  "fsAK9T": {
+    "defaultMessage": "Selecionar...",
+    "description": "This message appears in the input when no user is selected."
+  },
+  "fx39XE": {
+    "defaultMessage": "Ajuda",
+    "description": "This tooltip is displayed when the user hovers the support button"
+  },
+  "gAgkzF": {
+    "defaultMessage": "Criar Objetivo",
+    "description": "create new key result"
+  },
+  "gMArPa": {
+    "defaultMessage": "O Bud enviará lembretes para este time por email e por notificações para que todos respondam.",
+    "description": "Routine notification settings description subtitle"
+  },
+  "gOltd4": {
+    "defaultMessage": "Um ícone de seta para a direita que indica que o usuário pode avançar no histórico para conferir outras respostas da rotina.",
+    "description": "The alternative text explaining our graphic icon"
+  },
+  "gTym4f": {
+    "defaultMessage": "Progresso individual com base na média dos resultados-chave deste ano",
+    "description": "Yearly progress chart tooltip message"
+  },
+  "gUHlz3": {
+    "defaultMessage": "Seja o primeiro a comentar a resposta de {user}!",
+    "description": "This message appears in the empty state of comments in a user retrospective reply."
+  },
+  "gXiIKg": {
+    "defaultMessage": "Baixa confiança",
+    "description": "Title of low confidence health strategy"
+  },
+  "gZstKN": {
+    "defaultMessage": "Estado inicial",
+    "description": "The description for state cycle field on create cycle form"
+  },
+  "gbO+eS": {
+    "defaultMessage": "Se realmente tem certeza de que deseja fazer isso, confirme sua ação escrevendo \"{keyword}” no campo abaixo:",
+    "description": "This message is used as our default second stage description in our dangerous confirmation modal"
+  },
+  "gm1hfm": {
+    "defaultMessage": "Progresso do objetivo acumulado na semana",
+    "description": "This tooltip explains regarding our progress tag"
+  },
+  "goSPM7": {
+    "defaultMessage": "Você excluiu um {type}",
+    "description": "This text is displayed as the alert title, explaining what resource the user removed"
+  },
+  "gu4aCE": {
+    "defaultMessage": "Anual",
+    "description": "This text is used as prefix for our yearly cadences"
+  },
+  "h4VH9f": {
+    "defaultMessage": "desativar usuário",
+    "description": "This message appears in button to confirm the deactivate user action."
+  },
+  "h6wsCP": {
+    "defaultMessage": "Um ícone de seta para a esquerda que indica que o usuário pode retroceder no histórico para conferir outras respostas da rotina.",
+    "description": "The alternative text explaining our graphic icon"
+  },
+  "hFma0o": {
+    "defaultMessage": "Erro ao criar o ambiente",
+    "description": "The title of the toast that appears when we have an error while creating a new workspace"
+  },
+  "hL/jUm": {
+    "defaultMessage": "TAREFAS EM OKRs",
+    "description": "The title for tasks section in the profile page"
+  },
+  "hMD8CO": {
+    "defaultMessage": "Anterior",
+    "description": "The label of the button used to go back while creating a new workspace"
+  },
+  "hMXuTX": {
+    "defaultMessage": "Masculino",
+    "description": "This text is used accross our platform to identify the male gender"
+  },
+  "hPJxpx": {
+    "defaultMessage": "Média Confiança",
+    "description": "We use this tag to group every key result with confidence higher than 33 but lower than 66"
+  },
+  "hXlVqV": {
+    "defaultMessage": "Minhas Tarefas Pessoais",
+    "description": "The heading for the personal tasks section"
+  },
+  "hdWCC9": {
+    "defaultMessage": "Próximo",
+    "description": "The label of the button used to go forward while creating a new workspace"
+  },
+  "hfxyjh": {
+    "defaultMessage": "Veja nossos exemplos de OKRs",
+    "description": "This is a external link that goes to OKR examples made by Bud."
+  },
+  "hhH9fH": {
+    "defaultMessage": "Cargo do usuário inicial",
+    "description": "The user role while creating a new workspace"
+  },
+  "hn3cE7": {
+    "defaultMessage": "Progresso acumulado dessa semana",
+    "description": "This helper texts explains since when we are calculating your company progress"
+  },
+  "hohkHN": {
+    "defaultMessage": "Criar time",
+    "description": "The text is displayed as a heading in the add team modal"
+  },
+  "how6b8": {
+    "defaultMessage": "Um ícone de seta para a direita, usado no contexto de um link que redireciona o usuário para a página onde fala sobre a rotina de retrospectiva.",
+    "description": "A right arrow icon, used in the context of a link that redirects the user to the page where the retrospective routine is discussed."
+  },
+  "huUzRi": {
+    "defaultMessage": "custom emoji with apathetic expression",
+    "description": "This message is used as a description of emoji feeling 2"
+  },
+  "hwBdQ9": {
+    "defaultMessage": "Começar",
+    "description": "This message appears on the button the user uses to start responding to the routine form."
+  },
+  "i3PQl+": {
+    "defaultMessage": "Ciclo {period} {status} com sucesso!",
+    "description": "This message appears when we create a new cycle as a toast"
+  },
+  "i7i3Ew": {
+    "defaultMessage": "reportou {specific} resultado-chave:",
+    "description": "This message is the wrapper that appears on both types of confidence check ins."
+  },
+  "i915bK": {
+    "defaultMessage": "Líderes podem criar, editar e excluir objetivos e resultados-chave dos times aos quais pertencem.",
+    "description": "This string is used to describe the user edit role selection."
+  },
+  "i9bdpU": {
+    "defaultMessage": "Houve um erro inesperado ao criar seu objetivo. Tente novamente mais tarde",
+    "description": "This message appears as an error toast when the users tries to create a new objective but an error appears"
+  },
+  "iIm/1E": {
+    "defaultMessage": "marcou você em um comentário:",
+    "description": "This message is displayed to describe a notification that occurs when a user is tagged in a comment."
+  },
+  "iLO8sl": {
+    "defaultMessage": "Estas tarefas não estão relacionadas diretamente a um resultado-chave. Use-as para organizar melhor seu dia e deixá-lo mais produtivo :)",
+    "description": "The tooltip that shows when hovering over the personal tasks accordion title"
+  },
+  "iPv+uj": {
+    "defaultMessage": "Um ícone de uma linha reta na horizontal, representando que sua empresa não evolui desde o último evento de check-in",
+    "description": "This message is used by screen readers to explain our line icon"
+  },
+  "iVxx6N": {
+    "defaultMessage": "Essa semana",
+    "description": "This message appears with a subtitle in the cad that informs the user barrier status for the current week."
+  },
+  "iWDn4y": {
+    "defaultMessage": "Time de Apoio",
+    "description": "The label text above Support Team section in our key resulg single page or drawers"
+  },
+  "iZcwRX": {
+    "defaultMessage": "ACESSO DE EDIÇÃO",
+    "description": "The tooltip text for the edition access text"
+  },
+  "iivI51": {
+    "defaultMessage": "Neste mês",
+    "description": "This label is displayed if the date difference is 1 month or less"
+  },
+  "ijCibq": {
+    "defaultMessage": "Financeiro (Dólar)",
+    "description": "This message is displayed inside our key-result format select as the title of the coin USD format"
+  },
+  "j1c4SD": {
+    "defaultMessage": "PRODUTIVIDADE",
+    "description": "The title of the productivity graph"
+  },
+  "j8vYyP": {
+    "defaultMessage": "Rotinas da empresa estão sempre disponíveis para quem quiser responder, mas líderes podem desativar os lembretes para tornar as respostas opcionais em seu time.",
+    "description": "Routine notification settings modal subtitle"
+  },
+  "jCjr1X": {
+    "defaultMessage": "Preencha os campos obrigatórios para poder salvar este resultado-chave.",
+    "description": "This message appears in an error toast after the users tries to create a key-result but there are some validation errors in the form"
+  },
+  "jNuy4b": {
+    "defaultMessage": "Esta pessoa tem acesso ao Bud.",
+    "description": "This message appears in the tooltip of users with active account state."
+  },
+  "jRsXuq": {
+    "defaultMessage": "CHECK-INS",
+    "description": "The tooltip text for the check-ins text"
+  },
+  "jV4VhD": {
+    "defaultMessage": "Excluir ciclo",
+    "description": "This message is used as the label in the confirmation button while removing a cycle"
+  },
+  "jXZZd6": {
+    "defaultMessage": "Voltar ao presente",
+    "description": "go back to the present button description"
+  },
+  "jYw0F3": {
+    "defaultMessage": "Membros do time {isLoaded, select, true {({totalMembersCount})} other{}}",
+    "description": "This message is displayed inside the explore page, above the members section"
+  },
+  "jjr+Ye": {
+    "defaultMessage": "O objetivo foi removido com sucesso",
+    "description": "This message appears in a toast after the user removes an objective"
+  },
+  "jwsMer": {
+    "defaultMessage": "Último check-in",
+    "description": "the prefix that is displayed in the last update checkmark."
+  },
+  "jxyYl3": {
+    "defaultMessage": "Ordenada pelo progresso",
+    "description": "This tooltip appears when the user hovers the first column title"
+  },
+  "jzx+Hl": {
+    "defaultMessage": "Botão de opções",
+    "description": "This button allows you to choose an option that directs the user to the users profile or details."
+  },
+  "k3EFXK": {
+    "defaultMessage": "O nível de confiança descreve como você vê suas chances de alcançar esse resultado-chave dentro do prazo",
+    "description": "The tooltip of the check-in form. It appears when the user hovers the question mark icon"
+  },
+  "k4LTU8": {
+    "defaultMessage": "Dia de fim do período trimestral",
+    "description": "The label of the company quarterly date end while creating a new workspace"
+  },
+  "kDC8d3": {
+    "defaultMessage": "Configurações",
+    "description": "The page title that our users should see in the settings page"
+  },
+  "kHg/gs": {
+    "defaultMessage": "Você não tem nenhum resultado-chave em ciclos anteriores",
+    "description": "The label message that is displayed below our team at work image when the user has no key results in her/his key result view list"
+  },
+  "kLkKtK": {
+    "defaultMessage": "Um círculo amarelo, indicando que a confiançá é média",
+    "description": "A brief explanation for screen readers regarding the yellow status circle"
+  },
+  "kXNgkQ": {
+    "defaultMessage": "Progresso",
+    "description": "The text of the table head related to the Progress column"
+  },
+  "kawRcN": {
+    "defaultMessage": "Cancelar",
+    "description": "This message is displayed in the \"CANCEL\" button in the checkin form"
+  },
+  "kbccVO": {
+    "defaultMessage": "Seta para esquerda",
+    "description": "The description of the arrow icon."
+  },
+  "kjKwCU": {
+    "defaultMessage": "Comentários:",
+    "description": "This message appears as the empty state title of comments in a user retrospective reply"
+  },
+  "kynYpx": {
+    "defaultMessage": "Meus Resultados-Chave",
+    "description": "The page title that our users should see in the my key results page"
+  },
+  "l+HPdy": {
+    "defaultMessage": "Líder",
+    "description": "The tag title that is displayed when that user is the leader of the team"
+  },
+  "lApj0K": {
+    "defaultMessage": "Um ícone de carteira",
+    "description": "The desc message for the Wallet icon. This icon is used to ilustrate our key results"
+  },
+  "lBc00A": {
+    "defaultMessage": "Descreve o quão confiante a pessoa responsável por um resultado-chave está:",
+    "description": "This message is displayed as an introduction to our rich tooltip regarding the confidence level at the head of our key-results table"
+  },
+  "lCQz97": {
+    "defaultMessage": "Período",
+    "description": "The company yearly period input placeholder while creating a new workspace"
+  },
+  "lHI54p": {
+    "defaultMessage": "Para adicionar a este time uma pessoa que já tem acesso ao Bud, use o campo abaixo:",
+    "description": "This is the description of the modal that is used to add members to a team."
+  },
+  "lI5vJI": {
+    "defaultMessage": "Um ícone com três pontos. Ao clicar nele você abrirá algumas opções",
+    "description": "This text is displayed as the tree dots desc text in our timeline cards"
+  },
+  "lMYmAU": {
+    "defaultMessage": "Clique no botão abaixo para voltar para o Painel :)",
+    "description": "This message is displayed above the button in our not found error page"
+  },
+  "lMwPEm": {
+    "defaultMessage": "Inglês",
+    "description": "This is the name of the english language while we are creating a new user"
+  },
+  "lMxUF9": {
+    "defaultMessage": "Um ícone de seta para baixo, indicando que o progresso reduziu",
+    "description": "This desc message explains the decrease icon for screen readers"
+  },
+  "lQkUTL": {
+    "defaultMessage": "Inspiradores",
+    "description": "This title guides the creation of Objectives."
+  },
+  "lWcm/y": {
+    "defaultMessage": "Não existem resultados-chave com esse Nível de confiança.",
+    "description": "Tooltip content for health strategy box without key results"
+  },
+  "lhIu1G": {
+    "defaultMessage": "€ 100",
+    "description": "This message is displayed inside our key-result format select as the example of the coin GBP format"
+  },
+  "ll4kYl": {
+    "defaultMessage": "Data de fim",
+    "description": "The description for date-end cycle field"
+  },
+  "lm9HAr": {
+    "defaultMessage": "Um ícone de calendário",
+    "description": "The desc message for the Calendar icon. This icon is used to ilustrate our key results"
+  },
+  "loAGsF": {
+    "defaultMessage": "Variação",
+    "description": "This text is displayed in our check-in card, as a title for the left column in the progress increase section"
+  },
+  "loTYpj": {
+    "defaultMessage": "Inglês",
+    "description": "The user locale en-US option while creating a new workspace"
+  },
+  "lvyLZA": {
+    "defaultMessage": "Apagar esta resposta",
+    "description": "This message is used in the button where the user can delete a routine response."
+  },
+  "m4igWj": {
+    "defaultMessage": "Adicionar Comentário",
+    "description": "This is the label text that is displayed as a button as soon the check in form is displayed"
+  },
+  "m8Extk": {
+    "defaultMessage": "Um ícone de scanner",
+    "description": "The desc message for the Scan icon. This icon is used to ilustrate our key results"
+  },
+  "mK9HFR": {
+    "defaultMessage": "Dia de fim do período anual",
+    "description": "The label of the company yearly date end while creating a new workspace"
+  },
+  "mXb4/b": {
+    "defaultMessage": "Configurações | bud",
+    "description": "The page title that is displayed in the browser tab for the settings page"
+  },
+  "mbJq/U": {
+    "defaultMessage": "Tem certeza que deseja excluir o ciclo {period}?",
+    "description": "This message is used as the title in our first dialog while removing a cycle"
+  },
+  "mdG+CG": {
+    "defaultMessage": "Ciclos ativos",
+    "description": "This text is displayed as a tab where the user can click to change the view below it"
+  },
+  "mfowjk": {
+    "defaultMessage": "Um ícone de uma estrela, que aparece junto com a pergunta sobre as principais conquistas que o usuário teve na semana.",
+    "description": "The alternative text explaining our graphic icon"
+  },
+  "minQA9": {
+    "defaultMessage": "Redefinir senha",
+    "description": "This message is the description of the option to alter password of a user."
+  },
+  "mkTrvf": {
+    "defaultMessage": "Um ícone de pause, que aparece junto com a pergunta de se o usuario tem alguma barreira.",
+    "description": "The alternative text explaining our graphic icon"
+  },
+  "mkxm93": {
+    "defaultMessage": "Bud é uma plataforma para gerenciamento de OKRs.",
+    "description": "The default description for our page head meta description value"
+  },
+  "mnors5": {
+    "defaultMessage": "Sobre {nickname}",
+    "description": "The about section title for the user in the user card"
+  },
+  "mxk1xU": {
+    "defaultMessage": "Ative os lembretes para essa rotina!",
+    "description": "Routine notification settings modal title"
+  },
+  "n3PYQR": {
+    "defaultMessage": "Escreva sobre {isMyUser, select, true {você} other {{gender, select, MALE {o} FEMALE {a} other {o}} {firstName}}}",
+    "description": "This is the fallback value that goes on our user account settings page, at the seventh field to update the user informations. The fallback value appears if the user has no data at that field"
+  },
+  "n8OKn4": {
+    "defaultMessage": "Resultados-chave",
+    "description": "The title of the second section of My Week notification tab."
+  },
+  "nEQaGP": {
+    "defaultMessage": "OKRs Trimestrais {quarter}",
+    "description": "The summery title for the quarterly OKRs"
+  },
+  "nJ7CuJ": {
+    "defaultMessage": "Um ícone de relógio",
+    "description": "The desc message for the TimesSquare icon. This icon is used to ilustrate our key results"
+  },
+  "nPCTf0": {
+    "defaultMessage": "Redes sociais",
+    "description": "This title is displayed as the heading of the social media section in our user account settings page"
+  },
+  "nPjrcU": {
+    "defaultMessage": "Editar",
+    "description": "This message is displayer as soon as our user hovers the avatar"
+  },
+  "nWz8Nt": {
+    "defaultMessage": "Neutro",
+    "description": "The neutral gender for the company while creating a new workspace"
+  },
+  "na6BgW": {
+    "defaultMessage": "Histórico",
+    "description": "History, historic, archived items"
+  },
+  "ndABHM": {
+    "defaultMessage": "Admin",
+    "description": "This string is used to select the user admin role."
+  },
+  "nfdvr1": {
+    "defaultMessage": "Esperado",
+    "description": "This message is displayed in the chart tooltip of our key-result sidebar"
+  },
+  "nnWr7M": {
+    "defaultMessage": "Gênero",
+    "description": "This is the label that goes on our user account settings page, at the sixth field to update the user informations"
+  },
+  "npWxt7": {
+    "defaultMessage": "Um botão com um ícone de X. Ao clicar nele você irá cancelar a atualização do objetivo",
+    "description": "This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the cancel button"
+  },
+  "nqlxOI": {
+    "defaultMessage": "Você está em dia com seus compromissos no Bud.",
+    "description": "The page description that is displayed if the user has no key result in the this week notifications tab."
+  },
+  "nrToz/": {
+    "defaultMessage": "Voltar",
+    "description": "This message is displayed as a label in the button on our unknown error page"
+  },
+  "nriJkh": {
+    "defaultMessage": "Sim!",
+    "description": "This message appears when the user has a blockage during the week."
+  },
+  "oGyXN5": {
+    "defaultMessage": "Colegas com plano individual",
+    "description": "Friends with individual OKRs title"
+  },
+  "oh+3Gh": {
+    "defaultMessage": "Anual",
+    "description": "This option makes an cycle with yearly cadence"
+  },
+  "ooNWJL": {
+    "defaultMessage": "Adicionar Time de Apoio",
+    "description": "The label text for the add button icon in our key result single page or drawers"
+  },
+  "or8fId": {
+    "defaultMessage": "Voltar",
+    "description": "This message is displayed as a label in the button on our not found error page"
+  },
+  "p2UjMZ": {
+    "defaultMessage": "Minhas Coisas | bud",
+    "description": "The page title that is displayed in the browser tab"
+  },
+  "pAXjHu": {
+    "defaultMessage": "Retrospectiva",
+    "description": "This is the title of the retrospectives tab on the team page."
+  },
+  "pB9cMu": {
+    "defaultMessage": "Não",
+    "description": "This message appears as a description of the second option."
+  },
+  "pLYuso": {
+    "defaultMessage": "Um ícone de caneta. Ao clicar nele você irá editar esse campo",
+    "description": "The description for our pen icon. This message is used by screen readers to improve our accesibility"
+  },
+  "pQnPZP": {
+    "defaultMessage": "Ciclo pai",
+    "description": "The description for parent cycle field"
+  },
+  "pTXAs1": {
+    "defaultMessage": "Um ícone de seta para a direita. Ao clicar aqui voce será enviado para a página deste time",
+    "description": "This message is used by screen readers to explain the right arrow at our team lists component"
+  },
+  "pVkTLM": {
+    "defaultMessage": "Um ícone de coroa",
+    "description": "The desc message for the crown icon. This icon is used to ilustrate when a team card is actually a company"
+  },
+  "pXeDLf": {
+    "defaultMessage": "Sobrenome",
+    "description": "This is the label that goes on our user account settings page, at the second field to update the user informations"
+  },
+  "pbBzqW": {
+    "defaultMessage": "Lembrete ativo",
+    "description": "Message displayed when the routine notifications are active."
+  },
+  "pbVToL": {
+    "defaultMessage": "Criar um usuário",
+    "description": "This message appears as a button when a team has no members yet"
+  },
+  "piM/9+": {
+    "defaultMessage": "Explore este objetivo completo no Plano Individual de {user}",
+    "description": "This message appears in the individual objective tooltip"
+  },
+  "pmuG/e": {
+    "defaultMessage": "Líder",
+    "description": "This string is used to select the user edit role."
+  },
+  "poN086": {
+    "defaultMessage": "Um ícone circular, com bordas e um símbolo de mais ao centro",
+    "description": "This is the desc text that is displayed for screen readers"
+  },
+  "qGLpBy": {
+    "defaultMessage": "Date de início",
+    "description": "The description for date-start cycle field"
+  },
+  "qhchMM": {
+    "defaultMessage": "Representam as mais altas prioridades e comunicam essa direção com bastante clareza.",
+    "description": "This card guides the creation of Objectives."
+  },
+  "ql0LOi": {
+    "defaultMessage": "Procurar pessoas",
+    "description": "This message appears as a label in users search input."
+  },
+  "qp4Qmm": {
+    "defaultMessage": "Ir para o perfil de {username}",
+    "description": "This button redirects to the selected user."
+  },
+  "qrgfik": {
+    "defaultMessage": "Em uma frase, qual é a missão deste time?",
+    "description": "The placeholder to the description field in team add/edit modal"
+  },
+  "qsn7TW": {
+    "defaultMessage": "Adicionar nova tarefa pessoal",
+    "description": "The add new personal task button label"
+  },
+  "qytqsj": {
+    "defaultMessage": "Trimestral",
+    "description": "This text is used as prefix for our quarterly cadences"
+  },
+  "r1mfc1": {
+    "defaultMessage": "Informações pessoais",
+    "description": "This title is displayed as the heading of the personal informations section in our user account settings page"
+  },
   "rDaIQ2": {
     "defaultMessage": "Retrospectiva da semana",
     "description": "The title of the routine reminder notification"
@@ -2547,21 +2715,13 @@
     "defaultMessage": "Uma seta para baixo. Ao clicar nela você abrirá o menu de seleção",
     "description": "This is the desc attribute of our chevron down icon. It is used by screen readers"
   },
-  "RN1J2p": {
-    "defaultMessage": "Essa semana",
-    "description": "The title of the third column in our body table at the teams overview report in our dashboard"
-  },
-  "RojqOy": {
-    "defaultMessage": "Responder agora",
-    "description": "The text in the button to answer the routine"
+  "rZUL1Q": {
+    "defaultMessage": "baixa confiança em um",
+    "description": "This message appears as notification in confidence check in with low-confidence."
   },
   "rpLZ2J": {
     "defaultMessage": "Bud - Gestão de OKR e Estratégia",
     "description": "The title text of our logotype, it is displayed when an user hover the icon itself"
-  },
-  "RrW2fc": {
-    "defaultMessage": "Atualize seu cargo",
-    "description": "This is the fallback value that goes on our user account settings page, at the fifth field to update the user informations. The fallback value appears if the user has no data at that field"
   },
   "rsHltm": {
     "defaultMessage": "Não vamos alcançar o resultado a não ser que a gente mude nossa abordagem",
@@ -2570,30 +2730,6 @@
   "rvZQ2D": {
     "defaultMessage": "Progresso",
     "description": "This message is displayed as the title of the progress section inside check-in card"
-  },
-  "RWaMNF": {
-    "defaultMessage": "Um ícone de coração",
-    "description": "The desc message for the Heart icon. This icon is used to ilustrate our key results"
-  },
-  "RwKPpx": {
-    "defaultMessage": "EXCLUIR",
-    "description": "This message is used as keyword to delete a key-result"
-  },
-  "RZrZdZ": {
-    "defaultMessage": "Home",
-    "description": "The name of the Home page, located at \"/\""
-  },
-  "rZUL1Q": {
-    "defaultMessage": "baixa confiança em um",
-    "description": "This message appears as notification in confidence check in with low-confidence."
-  },
-  "S/F2Hk": {
-    "defaultMessage": "Detalhes",
-    "description": "The label text above the Description section in our key result single page or drawer"
-  },
-  "S/L2jr": {
-    "defaultMessage": "Sentimento",
-    "description": "The title of the feeling chart"
   },
   "s4h8ne": {
     "defaultMessage": "Adicionar uma Check-list",
@@ -2611,153 +2747,53 @@
     "defaultMessage": "conta ativa",
     "description": "This string is used to select the active cycles option."
   },
-  "S9cIsW": {
-    "defaultMessage": "Editar time",
-    "description": "The text is displayed as a heading in the add team modal"
-  },
-  "Sau4Na": {
-    "defaultMessage": "Nome",
-    "description": "The user first name input placeholder while creating a new workspace"
-  },
-  "Sb6dkV": {
-    "defaultMessage": "Ver detalhes",
-    "description": "This option will show a sidebar with the details of the selected user."
-  },
-  "SdgM/R": {
-    "defaultMessage": "Minha conta",
-    "description": "This title is displayed as the heading of the definitions menu section"
-  },
-  "SDzYq9": {
-    "defaultMessage": "Desculpe, mas houve um erro inesperado. Tente novamente mais tarde",
-    "description": "This message appears when the user tries to remove a given objective, but receives an error"
-  },
-  "SE9cO0": {
-    "defaultMessage": "Editar time",
-    "description": "Team edit button label"
-  },
-  "sEIpfE": {
-    "defaultMessage": "Sem time",
-    "description": "The text is displayed of the empty team option"
-  },
-  "SenoB2": {
-    "defaultMessage": "A página que você está procurando não foi encontrada!",
-    "description": "The title displayed in our not found error page"
-  },
   "sFYaLE": {
     "defaultMessage": "Check-in",
     "description": "This message is displayed as the form title, above the check-in form"
-  },
-  "sgr1cM": {
-    "defaultMessage": "Criar usuári{gender, select, MALE {o} FEMALE {a} other {o}}",
-    "description": "The label of the submit button of the create user form"
-  },
-  "ShzOP9": {
-    "defaultMessage": "Ícone de histórico",
-    "description": "Icon description for history icon"
-  },
-  "SiJuyU": {
-    "defaultMessage": "Um ícone de calendário, indicando que aqui você seleciona o ano que deseja filtrar",
-    "description": "This message is used by screen readers to explain the icon to the user"
   },
   "sJMgjv": {
     "defaultMessage": "Adicionar membro ao time",
     "description": "This message appears as an option in the team page while adding a user to team"
   },
-  "SK6+Sz": {
-    "defaultMessage": "Visão geral dos times",
-    "description": "The title of the teams overview"
-  },
-  "SL45P4": {
-    "defaultMessage": "Gênero",
-    "description": "The label of the gender field in the create user form"
-  },
-  "Sm4xi7": {
-    "defaultMessage": "Máquina do tempo",
-    "description": "This message is displayed as the title of the time machine section in a team's page"
-  },
-  "SmMx3s": {
-    "defaultMessage": "Colegas com planejamento individual",
-    "description": "Friends with individual OKRs title"
-  },
-  "Smwz9L": {
-    "defaultMessage": "Descreve o período no qual esse resultado-chave faz parte",
-    "description": "This tooltip explains the sixth column of the key result list"
-  },
-  "Sn7K6v": {
-    "defaultMessage": "Um ícone de sino, ao clicar nele você verá suas notificações",
-    "description": "The alternative text explaining our notification bell icon"
-  },
-  "sObsR1": {
-    "defaultMessage": "{unit, select, fallback {em {date}} other {{date}}}",
-    "description": "This text displays the latest report status for a given component, using a given date logic"
-  },
-  "sp/6lg": {
-    "defaultMessage": "Sobre",
-    "description": "This text is displayed in our check-in card, above the user comment if it exists"
-  },
   "sP2MCY": {
     "defaultMessage": "Mostrar menos",
     "description": "This text is displayed in the button that collapses the truncated text"
-  },
-  "SpAXmO": {
-    "defaultMessage": "Um ícone de calendário. Ele indica que nesse campo fica o prazo do objetivo",
-    "description": "The alternative text explaining our calendar icon in the objective accordion item"
   },
   "sQAoOl": {
     "defaultMessage": "Relaxe! Está tudo certo por aqui :)",
     "description": "The page title that is displayed if the user has no key result in the this week notifications tab."
   },
-  "SRIfUY": {
-    "defaultMessage": "Time",
-    "description": "The label of the team field in the create user form"
-  },
-  "SrOZ1m": {
-    "defaultMessage": "Criar usuário",
-    "description": "The sidebar title on our create user sidebar"
-  },
   "sSCvSb": {
     "defaultMessage": "Um ícone de \"x\". Ao clicar nele você irá remover esse item da checklist",
     "description": "This text is used by screen readers inside our key-result drawer to describe the X icon to remove a given item from the checklist"
+  },
+  "sX1k+9": {
+    "defaultMessage": "Resposta deletada com sucesso!",
+    "description": "This message appears in a toast indicating success in deleting a routines response."
+  },
+  "sgr1cM": {
+    "defaultMessage": "Criar usuári{gender, select, MALE {o} FEMALE {a} other {o}}",
+    "description": "The label of the submit button of the create user form"
+  },
+  "sp/6lg": {
+    "defaultMessage": "Sobre",
+    "description": "This text is displayed in our check-in card, above the user comment if it exists"
   },
   "ssM7Lj": {
     "defaultMessage": "Pertence ao objetivo",
     "description": "The label text above the Objective section in our key result single page or drawers"
   },
-  "SsQRcF": {
-    "defaultMessage": "Uma seta que ao ser clicada expande a checklist deste resultado-chave",
-    "description": "This message is used by screen readers to explain the collapse icon in our key-result sidebar on the checklist section"
-  },
-  "SU+pQ8": {
-    "defaultMessage": "Clique no botão <span>...</span> para criar o primeiro resultado-chave deste objetivo.",
-    "description": "This message is displayed in the key-results empty state inside the team page when an objective has no key-results"
-  },
-  "SWl7UB": {
-    "defaultMessage": "Um ícone de \"x\". Ao clicar nele você fechará o box de atualização de progresso",
-    "description": "This description is used for accessibility. Screen readers uses it when they hover the close icon button in our progress slider popover close button"
-  },
-  "SxsVDt": {
-    "defaultMessage": "Meta",
-    "description": "This is the label of the check-in form that indicates the goal for her/his key result"
-  },
-  "sYGIlp": {
-    "defaultMessage": "Minha conta",
-    "description": "This label defines the text on the first menu section option"
+  "t0YKyV": {
+    "defaultMessage": "Confirmar",
+    "description": "This message is used as the confirmation button when we are in the confirmation dialog"
   },
   "t0t6MQ": {
     "defaultMessage": "Voltar ao presente",
     "description": "The button title to go back to the present"
   },
-  "t0YKyV": {
-    "defaultMessage": "Confirmar",
-    "description": "This message is used as the confirmation button when we are in the confirmation dialog"
-  },
   "t3VVHw": {
     "defaultMessage": "Um ícone de X indicando que os dados neste campo não são válidos",
     "description": "This is used by screen readers to explain the X that appears when the users types a non-valid data in a given controlled field"
-  },
-  "T5iKmP": {
-    "defaultMessage": "{prefix} {cycle} {suffix}",
-    "description": "This message displays the cycle name with a given prefix"
   },
   "t6KyQZ": {
     "defaultMessage": "Um ícone de seta para cima, representando o quanto sua empresa evolui na última semana",
@@ -2767,45 +2803,13 @@
     "defaultMessage": "Ciclo {period} editado com sucesso!",
     "description": "This message appears when we create a new cycle as a toast"
   },
-  "T8ytLJ": {
-    "defaultMessage": "Objetivo",
-    "description": "The label text above the Objective section in our key result single page or drawer"
-  },
-  "TaXVmY": {
-    "defaultMessage": "Adicionar um OKR neste ciclo",
-    "description": "This message is displayed inside the team page, on the options menu of a cycle"
-  },
-  "tBBHmo": {
-    "defaultMessage": "Planejamento individual",
-    "description": "Individual OKR title on the navigation tab"
-  },
-  "TCJuuU": {
-    "defaultMessage": "Selecione ao menos um membro para completar a ação.",
-    "description": "This message appears as an error Toast when a user tries to add members to a team without selecting at least one."
-  },
   "tcWO3v": {
     "defaultMessage": "O logotipo do Bud. Sendo ele apenas o nome Bud escrito em caixa baixa na cor roxa",
     "description": "The alternative text explaining our logotype"
   },
-  "TGP9cN": {
-    "defaultMessage": "Salvar",
-    "description": "The button to create or edit a cycle on modal"
-  },
   "th1Ney": {
     "defaultMessage": "Hoje",
     "description": "This label is displayed if the date is today"
-  },
-  "TIorHN": {
-    "defaultMessage": "Existe um risco de não alcançarmos o resultado-chave, mas seguimos otimistas",
-    "description": "This text explains our tag to the user"
-  },
-  "TIXwh1": {
-    "defaultMessage": "Objetivo",
-    "description": "The label text above the Objective section in our key result single page or drawers"
-  },
-  "tJ0oU2": {
-    "defaultMessage": "Está silencioso por aqui!",
-    "description": "This text is the title of our empty state card inside our key result drawer"
   },
   "tj3TRS": {
     "defaultMessage": "Audaciosos",
@@ -2815,25 +2819,9 @@
     "defaultMessage": "Nome do Ciclo",
     "description": "This message is displayed as the column header for the cycle table in the cycle name column"
   },
-  "TKIxVB": {
-    "defaultMessage": "Definições",
-    "description": "This title is displayed as the heading of the definitions menu section"
-  },
   "tmyaek": {
     "defaultMessage": "Estado",
     "description": "This message is displayed as the column header for the users table in the state column"
-  },
-  "TN6PhK": {
-    "defaultMessage": "Meu perfil",
-    "description": "MainAppBar user menu first item option"
-  },
-  "Tp/cz3": {
-    "defaultMessage": "{confidence, select, roadblock {All key results with {confidence}} other {All {confidence} key results}}",
-    "description": "The title for the dashboard key results modal"
-  },
-  "Tsd4ry": {
-    "defaultMessage": "Veja os OKRs Individuais de { username }. Eles não interferem no progresso geral da empresa.",
-    "description": "Individual OKR subtitle of the page"
   },
   "tvj+/n": {
     "defaultMessage": "Visão geral do time",
@@ -2843,22 +2831,6 @@
     "defaultMessage": "Idioma",
     "description": "The user locale input placeholder while creating a new workspace"
   },
-  "TYmE01": {
-    "defaultMessage": "Progresso atual",
-    "description": "This tooltip is displayed when the user hovers the percentage progress above the bar"
-  },
-  "TzHlPJ": {
-    "defaultMessage": "Em manutenção | bud",
-    "description": "The page title of our under maintenance error page that is displayed in the browser tab"
-  },
-  "U1tYhb": {
-    "defaultMessage": "Adicionar",
-    "description": "The label text for the add button in our key result single page or drawers"
-  },
-  "U2EgRG": {
-    "defaultMessage": "Explorar | bud",
-    "description": "The page title that is displayed in the browser tab"
-  },
   "u4rqek": {
     "defaultMessage": "Q4",
     "description": "This button appears as an empty state while the user is selecting the cycle filter"
@@ -2867,17 +2839,25 @@
     "defaultMessage": "Responsável",
     "description": "The text of the table head related to the Owner column"
   },
-  "Ua7Hgq": {
-    "defaultMessage": "Voltar",
-    "description": "Return to overview page icon description"
+  "uIY7F5": {
+    "defaultMessage": "Retrospectiva da Semana",
+    "description": "Title of the content of the Retrospective tab on the teams page."
+  },
+  "uQUReU": {
+    "defaultMessage": "Estado atual",
+    "description": "The description for state cycle field on update cycle form"
+  },
+  "uUn4LH": {
+    "defaultMessage": "EXCLUIR",
+    "description": "This message is used as keyword to delete a cycle"
+  },
+  "uXQE/x": {
+    "defaultMessage": "Visualize o avanço geral de todas as áreas da empresa e os respectivos times que as compõem através das barras de evolução.",
+    "description": "The page description that is displayed in Google and screen readers"
   },
   "ub6rlW": {
     "defaultMessage": "Alta confiança",
     "description": "Title of high confidence health strategy"
-  },
-  "UBruoq": {
-    "defaultMessage": "Um ícone de com diversas superfícies, uma em cima da outra",
-    "description": "The alternative text explaining our stack icon"
   },
   "ucALDM": {
     "defaultMessage": "Ranking de Times do {quarter}",
@@ -2887,81 +2867,25 @@
     "defaultMessage": "Um ícone de quadrado arredondado com um lápis",
     "description": "The desc message for the EditSquare icon. This icon is used to ilustrate our key results"
   },
-  "uIY7F5": {
-    "defaultMessage": "Retrospectiva da Semana",
-    "description": "Title of the content of the Retrospective tab on the teams page."
-  },
-  "uL69e4": {
-    "defaultMessage": "Você ainda não criou nenhum OKR no seu Plano Individual.",
-    "description": "This message is displayed as the empty state message inside the User page"
-  },
   "ulnySu": {
     "defaultMessage": "Ciclos de OKR",
     "description": "This label defines the text on the first menu section option"
-  },
-  "UN5BY2": {
-    "defaultMessage": "EXCLUIR",
-    "description": "This message is used as the default keyword to type to confirm while removing a given resource"
-  },
-  "UNfjU2": {
-    "defaultMessage": "desativado",
-    "description": "This message appears when we have successfully activate/deactivate a cycle."
   },
   "unuB2s": {
     "defaultMessage": "Sobre esse check-in",
     "description": "This is the label text that is displayed above the input"
   },
-  "UozvhV": {
-    "defaultMessage": "Usuários",
-    "description": "This label defines the text on the first menu section option"
-  },
   "upeS+T": {
     "defaultMessage": "O Bud vai ficar fora do ar durante algumas horas enquanto arrumamos a casa. Esperamos estar de volta até: <highlight>{date} às {hour}h</highlight> Até lá! :)",
     "description": "This message is displayed as a description in our under maintenance error page"
-  },
-  "uQUReU": {
-    "defaultMessage": "Estado atual",
-    "description": "The description for state cycle field on update cycle form"
   },
   "usAoP+": {
     "defaultMessage": "Trimestral",
     "description": "This option makes an cycle with quarterly cadence"
   },
-  "Uu0OJV": {
-    "defaultMessage": "Um ícone de imagem. Ele indica que nesse campo fica seu avatar",
-    "description": "The alternative text explaining our image icon in the settings account page"
-  },
-  "UU1FXI": {
-    "defaultMessage": "Vincula o ciclo trimestral ao ciclo anual ao qual ele pertence.",
-    "description": "This message appears on tooltip that explain the parent cycle select field."
-  },
-  "uUn4LH": {
-    "defaultMessage": "EXCLUIR",
-    "description": "This message is used as keyword to delete a cycle"
-  },
-  "UUo+Pt": {
-    "defaultMessage": "Este time é uma empresa",
-    "description": "The title message for the crown icon. This icon is used to ilustrate when a team card is actually a company"
-  },
-  "uXQE/x": {
-    "defaultMessage": "Visualize o avanço geral de todas as áreas da empresa e os respectivos times que as compõem através das barras de evolução.",
-    "description": "The page description that is displayed in Google and screen readers"
-  },
-  "UYwpSr": {
-    "defaultMessage": "Time",
-    "description": "This message is displayed as the column header for the key-result table in the team column"
-  },
-  "UZnhGI": {
-    "defaultMessage": "Passo 1",
-    "description": "The label of the first step while creating a new workspace"
-  },
-  "VBdX86": {
-    "defaultMessage": "{username} ainda não tem nenhuma tarefa em seu nome nos OKRs da empresa.",
-    "description": "The empty state message header when a user have no tasks"
-  },
-  "vbnV7B": {
-    "defaultMessage": "Português",
-    "description": "This message is used as the label for the portuguese language in our locale switcher"
+  "uxjg0W": {
+    "defaultMessage": "Não foi possível deletar a resposta!",
+    "description": "This message appears in a toast indicating that it was not possible to delete a routines response."
   },
   "vCWYpE": {
     "defaultMessage": "Este time está dentro de:",
@@ -2971,37 +2895,9 @@
     "defaultMessage": "Está silencioso por aqui",
     "description": "This text is the title of our empty state card inside our key result drawers"
   },
-  "VDLkuO": {
-    "defaultMessage": "Mostrar mais",
-    "description": "This text is displayed in the button that expands a truncated text"
-  },
   "vEzcix": {
     "defaultMessage": "Times",
     "description": "This message is displayed as the column header for the users table in the teams column"
-  },
-  "VFj8OD": {
-    "defaultMessage": "Título copiado com sucesso.",
-    "description": "This message appears in the toast when you successfully copies the title of the key result"
-  },
-  "vfstY8": {
-    "defaultMessage": "Torne mensurável definindo um número como indicador de sucesso.",
-    "description": "The second description of the tip when you are creating a KR."
-  },
-  "vgU7fC": {
-    "defaultMessage": "Check-in pendente",
-    "description": "This string is used as the description for the icon that indicates that the key-result has not been updated"
-  },
-  "VhgGax": {
-    "defaultMessage": "",
-    "description": ""
-  },
-  "VHOea1": {
-    "defaultMessage": "Excluir resultado-chave",
-    "description": "This message is used as the label in the confirmation button while removing a key-result"
-  },
-  "vhq3gt": {
-    "defaultMessage": "Feminino",
-    "description": "The user gender female option while creating a new workspace"
   },
   "vHTPEb": {
     "defaultMessage": "Ciclo {period} criado com sucesso!",
@@ -3011,33 +2907,25 @@
     "defaultMessage": "Esse link pode estar expirado ou a URL está errada.",
     "description": "The description displayed in our not found error page"
   },
-  "VltGNp": {
-    "defaultMessage": "Um desenho de fantasma, indicando que este resultado-chave não tem nenhum card de atividade",
-    "description": "This text is used by screen readers to explain our ghost image inside our key result drawers"
-  },
-  "VLU792": {
-    "defaultMessage": "Check-in",
-    "description": "The title of the button to create a check-in in the check-in notifications tab, when clicked it opens the key result drawer."
-  },
-  "vm0Yuj": {
-    "defaultMessage": "Meu perfil | bud",
-    "description": "The page title that is displayed in the browser tab for the my profile page"
-  },
-  "VNHZWm": {
-    "defaultMessage": "Período",
-    "description": "The name label. It is displayed in the Cycle section, as a label of the name property"
-  },
   "vO+kQj": {
     "defaultMessage": "O ciclo está fechado. Não é possível editar nem atualizar os OKRs, mas eles podem ser consultados pelo histórico.",
     "description": "This string is used to describe the cycles not-active status option."
   },
-  "VPJIpc": {
-    "defaultMessage": "OKRs",
-    "description": "This message is displayed above the empty state inside the active cycles section at the User page"
+  "vbnV7B": {
+    "defaultMessage": "Português",
+    "description": "This message is used as the label for the portuguese language in our locale switcher"
   },
-  "vppqyA": {
-    "defaultMessage": "Os OKRs do Plano Individual são definido por você. Eles não interferem no progresso da empresa.",
-    "description": "Individual OKR subtitle of the page"
+  "vfstY8": {
+    "defaultMessage": "Torne mensurável definindo um número como indicador de sucesso.",
+    "description": "The second description of the tip when you are creating a KR."
+  },
+  "vgU7fC": {
+    "defaultMessage": "Check-in pendente",
+    "description": "This string is used as the description for the icon that indicates that the key-result has not been updated"
+  },
+  "vhq3gt": {
+    "defaultMessage": "Feminino",
+    "description": "The user gender female option while creating a new workspace"
   },
   "vqeE5J": {
     "defaultMessage": "Lembretes de rotina",
@@ -3047,29 +2935,9 @@
     "defaultMessage": "Botão de opções.",
     "description": "This button allows you to view details, reset password or deactivate a users account."
   },
-  "VSS4F8": {
-    "defaultMessage": "{unit, select, fallback {desde {date}} other {{date}}}",
-    "description": "This text displays the latest report status for a given component, using a given date logic"
-  },
-  "VUKPKt": {
-    "defaultMessage": "Cancelar",
-    "description": "This is a button label displayed inside the insert key-result drawer. This is the first button"
-  },
   "vv49le": {
     "defaultMessage": "Nome do usuário inicial",
     "description": "The user first name while creating a new workspace"
-  },
-  "VW9LHA": {
-    "defaultMessage": "Email de redefinição de senha enviado com sucesso.",
-    "description": "This message appears in a toast after the user ask to reset password."
-  },
-  "vyGEtA": {
-    "defaultMessage": "Estado atual",
-    "description": "The description for state cycle field"
-  },
-  "Vytr8A": {
-    "defaultMessage": "Editar ciclo",
-    "description": "The title for cycle modal"
   },
   "vzHp1e": {
     "defaultMessage": "Precisando de inspiração? Lembre-se: os melhores objetivos são...",
@@ -3079,29 +2947,17 @@
     "defaultMessage": "Líder:",
     "description": "The label to the leader field in team add/edit modal"
   },
-  "W/yMJH": {
-    "defaultMessage": "Financeiro (Libra)",
-    "description": "This message is displayed inside our key-result format select as the title of the coin GBP format"
-  },
-  "W37c+K": {
-    "defaultMessage": "Um ícone de check. Ele representa a quantidade de itens marcados como completo em sua checklist",
-    "description": "This text is used by screen readers to explain the check icon in our key-result drawer checklist section"
-  },
-  "W3eJuC": {
-    "defaultMessage": "Estes são os resultados-chave e as tarefas atribuídos a você.",
-    "description": "The page sub title that our users should see in the my things page"
-  },
   "w9Qh/X": {
     "defaultMessage": "confira as novas respostas em {team}",
     "description": "The subtitle of the routine reminder notification"
   },
-  "W9swHV": {
-    "defaultMessage": "Configurações",
-    "description": "This tooltip is displayed when the user hovers the settings icon"
+  "wJjuae": {
+    "defaultMessage": "A pessoa responsável por garantir que esse resultado-chave aconteça",
+    "description": "This tooltip explains the seventh column of the key result list"
   },
-  "Wa22G2": {
-    "defaultMessage": "Média confiança",
-    "description": "Title of medium confidence health strategy"
+  "wWbkGb": {
+    "defaultMessage": "OKRs",
+    "description": "This is the title of the okrs tab on the team page."
   },
   "waPxPB": {
     "defaultMessage": "Idioma do usuário inicial",
@@ -3115,49 +2971,13 @@
     "defaultMessage": "Voltar",
     "description": "Label for return to overview icon"
   },
-  "WEXvlm": {
-    "defaultMessage": "Experimente usar esse espaço para listar suas prioridades do dia, por exemplo :)",
-    "description": "Personal tasks empty state sub title"
-  },
   "wiFglx": {
     "defaultMessage": "Responsável",
     "description": "This label appears above the sixth input in our insert key-result drawer"
   },
-  "WIR0FJ": {
-    "defaultMessage": "Masculino",
-    "description": "The male gender for the company while creating a new workspace"
-  },
-  "WiYOXK": {
-    "defaultMessage": "Valor Inicial",
-    "description": "This label appears above the fourth input in our insert key-result drawer"
-  },
-  "wJjuae": {
-    "defaultMessage": "A pessoa responsável por garantir que esse resultado-chave aconteça",
-    "description": "This tooltip explains the seventh column of the key result list"
-  },
-  "Wk0KQD": {
-    "defaultMessage": "Lembrete inativo",
-    "description": "Message displayed when the routine notifications are inactive."
-  },
-  "WKevJy": {
-    "defaultMessage": "Clique aqui para editar esse campo",
-    "description": "The title for our pen icon. This message is displayed in our UI as a tooltip"
-  },
-  "WkRV5L": {
-    "defaultMessage": "Cancelar",
-    "description": "This message appears as a cancel button in the modal while deleting a given resource"
-  },
-  "WkvrVY": {
-    "defaultMessage": "Procurar times",
-    "description": "The text is displayed as a placeholder in any search input regarding teams"
-  },
   "wlwyTd": {
     "defaultMessage": "Buscar membros",
     "description": "This message is used in the search input while searching for users"
-  },
-  "WR43/0": {
-    "defaultMessage": "Você ainda não tem nenhuma tarefa.",
-    "description": "The empty state message header when you have no tasks"
   },
   "wsXNFt": {
     "defaultMessage": "Responder",
@@ -3167,21 +2987,9 @@
     "defaultMessage": "Descrição:",
     "description": "The label to the description field in team add/edit modal"
   },
-  "Ww/cjH": {
-    "defaultMessage": "Com Barreira",
-    "description": "The title of the with barrier chart"
-  },
-  "wWbkGb": {
-    "defaultMessage": "OKRs",
-    "description": "This is the title of the okrs tab on the team page."
-  },
   "wwt9p1": {
     "defaultMessage": "Um círculo com um ponto de interrogação ao centro",
     "description": "This message describes the info circle icon to our screen readers"
-  },
-  "X+heBq": {
-    "defaultMessage": "Routine notification settings button",
-    "description": "Label for routine notification settings button"
   },
   "x/2y46": {
     "defaultMessage": "Veja nossos exemplos de OKRs",
@@ -3190,10 +2998,6 @@
   "x24wfc": {
     "defaultMessage": "Explore este objetivo completo no time de {team}",
     "description": "This message appears in the objective tooltip"
-  },
-  "X2V7x7": {
-    "defaultMessage": "Confiança",
-    "description": "The text of the table head related to the Confidence Level column"
   },
   "x30AaU": {
     "defaultMessage": "Clique aqui para fazer uma busca",
@@ -3211,177 +3015,57 @@
     "defaultMessage": "Cancelar",
     "description": "This text is displayed as the button that will cancel the update for ou goal update popover inside the key-result drawers"
   },
-  "xaHzA0": {
-    "defaultMessage": "Sobrenome",
-    "description": "The user last name input placeholder while creating a new workspace"
-  },
-  "XbzHtU": {
-    "defaultMessage": "custom emoji with smile on face",
-    "description": "This message is used as a description of emoji feeling 5"
-  },
-  "XCDzMo": {
-    "defaultMessage": "Botão de opções",
-    "description": "This button allows you to choose an option that can allow you to copy the title ou exclude the KR."
-  },
-  "Xcxvrr": {
-    "defaultMessage": "A calendar icon",
-    "description": "The description of the calendar icon at the routine notification component."
-  },
-  "xe74UT": {
-    "defaultMessage": "Em OKRs, costuma-se mirar em atingir ao menos 70% das metas. Para atingir esse patamar até o fim do ciclo, o progresso atual esperado é de {progress}%.",
-    "description": "Tooltip message to show when hovering the help icon on projected progress"
-  },
-  "XEey8C": {
-    "defaultMessage": "Arraste até o novo valor para iniciar um check-in",
-    "description": "This tooltip is displayed when the user hovers the thumb of our progress bar"
-  },
-  "XENgso": {
-    "defaultMessage": "Médio",
-    "description": "We use this tag to group every key result with confidence higher than 33 but lower than 66"
-  },
-  "xfx/rc": {
-    "defaultMessage": "Um botão com um ícone de confirmação. Ao clicar nele você irá salvar sua atualização do objetivo",
-    "description": "This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the check button"
-  },
-  "XGKUNq": {
-    "defaultMessage": "Para essa semana",
-    "description": "The title of the section of the key results without check-in in the week."
-  },
   "xIe3i6": {
     "defaultMessage": "Reativar conta",
     "description": "This message is the description of the option to reactivate a user account."
-  },
-  "XiSFEr": {
-    "defaultMessage": "Erro inesperado | bud",
-    "description": "The page title of our unknown error page that is displayed in the browser tab"
   },
   "xJJ9uE": {
     "defaultMessage": "Desculpe, mas houve um erro inesperado. Tente novamente mais tarde",
     "description": "This message appears when the user tries to remove a given cycle, but receives an error"
   },
-  "xkN783": {
-    "defaultMessage": "",
-    "description": ""
-  },
-  "XL/hXA": {
-    "defaultMessage": "Faz tempo que ninguém interage nesse resultado-chave. Que tal compartilhar uma informação relevante com o time? :)",
-    "description": "This text gives more details regarding our empty state card in the key result drawer"
-  },
-  "XN0ZEi": {
-    "defaultMessage": "Passo 2",
-    "description": "The label of the second step while creating a new workspace"
-  },
-  "XNkzYe": {
-    "defaultMessage": "Um ícone de pin de localização",
-    "description": "The desc message for the Location icon. This icon is used to ilustrate our key results"
-  },
-  "XnTd/f": {
-    "defaultMessage": "Novo valor",
-    "description": "This text is displayed in our check-in card, as a title for the right column in the progress increase section"
-  },
-  "XOLhDn": {
-    "defaultMessage": "Adicionar",
-    "description": "This message appears on the add a user to the team button when the team is empty."
-  },
   "xPoUwI": {
     "defaultMessage": "Um desenho de uma engrenagem para o botão de edição de time",
     "description": "The gear icon description"
-  },
-  "XvdEsU": {
-    "defaultMessage": "Um ícone de tres pontos, indicando que ao clicar aqui um menu se expandirá",
-    "description": "The description for screen readers regarding the three dots icon in the objectives accordion"
   },
   "xVR0F1": {
     "defaultMessage": "Apelido",
     "description": "This is the label that goes on our user account settings page, at the third field to update the user informations"
   },
-  "xwbI5E": {
-    "defaultMessage": "Atenção! Esta ação não pode ser desfeita",
-    "description": "This message is displayed as the title for the danger confirmation modal while removing a given resource"
-  },
   "xXxjVp": {
     "defaultMessage": "Existe um fator externo impedindo o progresso desse resultado-chave",
     "description": "This text explains our tag to the user"
   },
-  "XYg5xf": {
-    "defaultMessage": "Clique aqui para editar suas configurações",
-    "description": "The title text of our settings icon, it is displayed when an user hover the icon itself"
+  "xaHzA0": {
+    "defaultMessage": "Sobrenome",
+    "description": "The user last name input placeholder while creating a new workspace"
   },
-  "XyhQJo": {
-    "defaultMessage": "O ciclo foi removido com sucesso",
-    "description": "This message appears in a toast after the user removes a cycle"
+  "xe74UT": {
+    "defaultMessage": "Em OKRs, costuma-se mirar em atingir ao menos 70% das metas. Para atingir esse patamar até o fim do ciclo, o progresso atual esperado é de {progress}%.",
+    "description": "Tooltip message to show when hovering the help icon on projected progress"
+  },
+  "xfx/rc": {
+    "defaultMessage": "Um botão com um ícone de confirmação. Ao clicar nele você irá salvar sua atualização do objetivo",
+    "description": "This text is displayed inside the objective accordion at the team page. It is used by screen readers to explain the check button"
   },
   "xywRWB": {
     "defaultMessage": "Um ícone de check. Ao clicar nele você irá salvar suas alterações",
     "description": "This text is used by screen readers to explain the check icon. This icon appears below the EditableTextArea. It is used to save the edition of the field"
   },
-  "XZcPVc": {
-    "defaultMessage": "Uma mulher analisando gráficos e apontando com um dedo.",
-    "description": "The alternative text explaining the empty item image"
-  },
-  "XZF51J": {
-    "defaultMessage": "Uma imagem que representa a ausência de novas notificações.",
-    "description": "The alternative text explain the empty state message when no more notifications to listing."
-  },
-  "Y+MtZe": {
-    "defaultMessage": "Nome",
-    "description": "This is the label that goes on our user account settings page, at the first field to update the user informations"
-  },
   "y18Ymm": {
     "defaultMessage": "Tudo certo por aqui! Navegue pelos times para explorar os resultados-chave com alta confiança.",
     "description": "Tooltip content for high confidence health strategy box"
-  },
-  "Y1oyYG": {
-    "defaultMessage": "Um ícone de seta para cima, indicando que o progresso aumentou",
-    "description": "This desc message explains the increase icon for screen readers"
-  },
-  "Y8TWo2": {
-    "defaultMessage": "Plano Individual",
-    "description": "Individual OKR title on the navigation tab"
-  },
-  "YETxgV": {
-    "defaultMessage": "Em OKRs, costuma-se mirar em atingir ao menos 70% das metas. Para atingir esse patamar até o fim do ciclo, o progresso atual esperado é de 67%.",
-    "description": "Tooltip message to show when hovering the help icon on projected progress"
-  },
-  "YFb9UA": {
-    "defaultMessage": "Ir para o perfil",
-    "description": "This option will redirect the user to the selected user profile."
-  },
-  "yfhIM+": {
-    "defaultMessage": "Cancelar",
-    "description": "Text in the cancel action button"
   },
   "yK87+y": {
     "defaultMessage": "Data de início",
     "description": "The company yearly date start input placeholder while creating a new workspace"
   },
-  "Ykg0Jh": {
-    "defaultMessage": "Realizado por <highlight>{author}</highlight> {unit, select, fallback {em} other {}} {time}",
-    "description": "This text is displayed as a helper text, below the check-in card title"
-  },
-  "YmUBcv": {
-    "defaultMessage": "Editar time",
-    "description": "The tooltip on the gear icon that edits the team"
-  },
-  "yq7/PT": {
-    "defaultMessage": "Artigos de suporte",
-    "description": "MainAppBar user menu second item option"
-  },
-  "yROxQI": {
-    "defaultMessage": "Team",
-    "description": "This message is displayed as the column header for the key-result table in the team column"
-  },
   "yRU1Bz": {
     "defaultMessage": "{username} ainda não está envolvido em nenhum resultado-chave.",
     "description": "The label message that is displayed below our team at work image when a user has no key results in her/his key result view list"
   },
-  "ytvOyM": {
-    "defaultMessage": "Meus Resultados-Chave",
-    "description": "MainAppBar menu item that links to \"My Key Results\" page"
-  },
-  "YUvWwS": {
-    "defaultMessage": "Registro",
-    "description": "It is used as a fallback if the component has no card type defined for it"
+  "yfhIM+": {
+    "defaultMessage": "Cancelar",
+    "description": "Text in the cancel action button"
   },
   "yw+DGB": {
     "defaultMessage": "Sobrenome",
@@ -3390,26 +3074,6 @@
   "ywBP21": {
     "defaultMessage": "Inativo",
     "description": "This string is used to select the not-active cycles option."
-  },
-  "YxKyjP": {
-    "defaultMessage": "Planejamento individual",
-    "description": "Individual OKR title of the page"
-  },
-  "YxNkP6": {
-    "defaultMessage": "Check-in",
-    "description": "This text is displayed in some places in our timeline card, showing the type of the card in a friendly name"
-  },
-  "YzN13f": {
-    "defaultMessage": "Um ícone de um alvo, indicando que essa é a meta do seu resultado-chave",
-    "description": "The description text for the key-result section goal icon"
-  },
-  "YznDPX": {
-    "defaultMessage": "Resultado-chave criado com sucesso!",
-    "description": "This message appears after the user creates a new key-result as a toast"
-  },
-  "z1FXkV": {
-    "defaultMessage": "Ciclo",
-    "description": "The label text above the Cycle section in our key result single page or drawer"
   },
   "z2jAqq": {
     "defaultMessage": "Um ícone com o sinal de \"mais\". Ao clicar aqui você irá abrir o menu para inserir um novo subtime",
@@ -3422,38 +3086,6 @@
   "z4STCs": {
     "defaultMessage": "Como vai o desempenho d{gender, select, MALE {o} FEMALE {a} other {o}} <highlight>{company}</highlight> nesse trimestre?",
     "description": "The title of the header section in our company overview report"
-  },
-  "z75EmS": {
-    "defaultMessage": "Visualize e atualize as preferências referentes a plataforma",
-    "description": "The page description that is displayed in Google and screen readers for the platform settings page"
-  },
-  "Z9w45E": {
-    "defaultMessage": "Usuários com essa permissão podem editar e fazer check-in apenas dos resultados-chave que fazem parte.",
-    "description": "This string is used to describe the user default role selection."
-  },
-  "zaC3Cb": {
-    "defaultMessage": "ativado",
-    "description": "This message appears when we are unable to activate/deactivate a cycle"
-  },
-  "zcIxrk": {
-    "defaultMessage": "Excluir ciclo",
-    "description": "This message is the description of the option to delete a cycle."
-  },
-  "ZCWI2f": {
-    "defaultMessage": "Criar novo ciclo",
-    "description": "The title for cycle modal"
-  },
-  "ze3hqu": {
-    "defaultMessage": "Estamos trabalhando em melhorias para você! :)",
-    "description": "The title displayed in our under maintenance error page"
-  },
-  "zennqC": {
-    "defaultMessage": "Adicionar novo item",
-    "description": "This label appears in our key-result sidebar drawer, in the end of our checklist"
-  },
-  "zev4wl": {
-    "defaultMessage": "Um ícone de bandeira, inidcando a meta do resultado-chave no qual você está fazendo check-in",
-    "description": "This is a message explaining the flag icon in our check-in form"
   },
   "zEyzo8": {
     "defaultMessage": "Um círculo roxo, indicando que o resultado-chave tem uma barreira",
@@ -3471,50 +3103,6 @@
     "defaultMessage": "Clique aqui para ver suas notificações",
     "description": "The title text of our notification bell, it is displayed when an user hover the icon itself"
   },
-  "ZkqTBK": {
-    "defaultMessage": "ADICIONAR",
-    "description": "This button is used to add selected members to a team."
-  },
-  "Zmffm0": {
-    "defaultMessage": "Fechar",
-    "description": "This message is displayed as the title text for our close icon in our check-in form"
-  },
-  "zmPWcg": {
-    "defaultMessage": "Papel",
-    "description": "This message is displayed as the column header for the users table in the role column"
-  },
-  "ZmSQ0o": {
-    "defaultMessage": "Você ainda não respondeu essa semana.",
-    "description": "The text that appears at the bottom of the answer component if you didn't answer the routine yet"
-  },
-  "ZMT2Ze": {
-    "defaultMessage": "Criar novo Resultado-Chave",
-    "description": "This is the first option that appears when you open the menu of a given objective inside the accordion button"
-  },
-  "Zmw2VE": {
-    "defaultMessage": "Usuários",
-    "description": "The subtitle page."
-  },
-  "Zn0eYa": {
-    "defaultMessage": "Um desenho de uma mulher e um homem, cada qual segurando um pedaço de um quebra-cabeça e colaborando para montá-lo",
-    "description": "The alternative text explaining our team at work image"
-  },
-  "znpwST": {
-    "defaultMessage": "Q3",
-    "description": "This button appears as an empty state while the user is selecting the cycle filter"
-  },
-  "ZPSK4M": {
-    "defaultMessage": "Insira um título para este Resultado-chave",
-    "description": "The placeholder for the first input in our key-result insert drawer form"
-  },
-  "zQoORA": {
-    "defaultMessage": "Tem certeza que deseja excluir este {type}?",
-    "description": "This message is displayed as the title for the confirmation modal while removing a given resource"
-  },
-  "zsB72A": {
-    "defaultMessage": "Pré-visualização",
-    "description": "This title is displayed as the heading of the user card preview section in our user account settings page"
-  },
   "zUEhBk": {
     "defaultMessage": "Um banco vazio, representando que não tem ninguém aqui",
     "description": "The alternative text explaining the empty bench image"
@@ -3523,24 +3111,36 @@
     "defaultMessage": "{selectedusersquantity} pessoas",
     "description": "This message appears in the input when multiple users are selected."
   },
-  "ZVTdlV": {
-    "defaultMessage": "Um ícone de ingresso de cinema",
-    "description": "The desc message for the TicketStar icon. This icon is used to ilustrate our key results"
-  },
-  "ZvutBL": {
-    "defaultMessage": "Cadência",
-    "description": "This message is displayed as the column header for the cycles table in the cadence column"
-  },
   "zWpOXa": {
     "defaultMessage": "Criar",
     "description": "The button to create or edit a cycle on modal"
   },
-  "ZXpNJ2": {
-    "defaultMessage": "Um ícone de gráfico de pizza",
-    "description": "The desc message for the Graph icon. This icon is used to ilustrate our key results"
+  "zaC3Cb": {
+    "defaultMessage": "ativado",
+    "description": "This message appears when we are unable to activate/deactivate a cycle"
   },
-  "texterify_timestamp": {
-    "defaultMessage": "2022-10-27T01:24:37Z",
-    "description": ""
+  "zcIxrk": {
+    "defaultMessage": "Excluir ciclo",
+    "description": "This message is the description of the option to delete a cycle."
+  },
+  "ze3hqu": {
+    "defaultMessage": "Estamos trabalhando em melhorias para você! :)",
+    "description": "The title displayed in our under maintenance error page"
+  },
+  "zev4wl": {
+    "defaultMessage": "Um ícone de bandeira, inidcando a meta do resultado-chave no qual você está fazendo check-in",
+    "description": "This is a message explaining the flag icon in our check-in form"
+  },
+  "zmPWcg": {
+    "defaultMessage": "Papel",
+    "description": "This message is displayed as the column header for the users table in the role column"
+  },
+  "znpwST": {
+    "defaultMessage": "Q3",
+    "description": "This button appears as an empty state while the user is selecting the cycle filter"
+  },
+  "zsB72A": {
+    "defaultMessage": "Pré-visualização",
+    "description": "This title is displayed as the heading of the user card preview section in our user account settings page"
   }
 }

--- a/src/components/Base/MenuOptions/index.tsx
+++ b/src/components/Base/MenuOptions/index.tsx
@@ -1,0 +1,62 @@
+import { Menu, MenuButton, MenuItem, MenuList, Stack, StyleProps, Text } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import TreeDotsIcon from 'src/components/Icon/TreeDots'
+
+import messages from './messages'
+
+export interface Option {
+  value: string
+  onSelect: () => Promise<void> | void
+}
+
+interface IMenuOptions extends StyleProps {
+  options: Option[]
+  legend?: string
+}
+
+const CustomMenuOptions = ({ options, legend, ...rest }: IMenuOptions) => {
+  const intl = useIntl()
+
+  return (
+    <Stack align="center" {...rest}>
+      <Menu placement="bottom-end" variant="action-list">
+        <MenuButton
+          bg="new-gray.200"
+          borderRadius={10}
+          color="new-gray.700"
+          p={2}
+          _hover={{
+            bg: 'new-gray.100',
+            color: 'new-gray.500',
+          }}
+          _active={{
+            bg: 'new-gray.100',
+            color: 'new-gray.500',
+          }}
+        >
+          <TreeDotsIcon
+            desc={intl.formatMessage(messages.treeDotsIconDescription)}
+            fill="currentColor"
+            fontSize="2xl"
+          />
+        </MenuButton>
+        <MenuList>
+          {options.map(({ onSelect, value }) => (
+            <MenuItem key={value + Math.random().toString()} onClick={onSelect}>
+              {value}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+      {legend && (
+        <Text color="new-gray.600" fontSize={12}>
+          {legend}
+        </Text>
+      )}
+    </Stack>
+  )
+}
+
+export default CustomMenuOptions

--- a/src/components/Base/MenuOptions/messages.ts
+++ b/src/components/Base/MenuOptions/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl'
+
+type customMenuOptionMessages = 'treeDotsIconDescription'
+
+export default defineMessages<customMenuOptionMessages>({
+  treeDotsIconDescription: {
+    defaultMessage: 'Ícone com três pontos usado em um botão que abre um menu de opções.',
+    id: 'e/i9Ml',
+    description: 'Icon with three dots used on a button that opens an options menu.',
+  },
+})

--- a/src/components/Notifications/Modal/index.tsx
+++ b/src/components/Notifications/Modal/index.tsx
@@ -65,7 +65,7 @@ interface NotificationsModalProperties {
 
 const NotificationsModal = ({ userId, isOpen }: NotificationsModalProperties) => {
   const intl = useIntl()
-  const routines = usePendingRoutines()
+  const { routines } = usePendingRoutines()
   const { dispatch: dispatchTabCheckInClick } = useEvent(EventType.TAB_THIS_WEEK_CLICK)
   const { dispatch: dispatchTabNotificationClick } = useEvent(EventType.TAB_NOTIFICATION_CLICK)
 

--- a/src/components/Page/Team/Tabs/content/messages.ts
+++ b/src/components/Page/Team/Tabs/content/messages.ts
@@ -19,8 +19,8 @@ export default defineMessages<ExploreTeamTabsContentMessage>({
 
   tabRetrospectivePageDescription: {
     defaultMessage:
-      'Compartilhe suas as prioridades, conquistas e barreiras com seu time. Acompanhe e interaja com seus colegas sobre a jornada deles.',
-    id: 'kAwViv',
+      'Compartilhe suas as prioridades, conquistas e barreiras com seu time. Acompanhe e interaja com seus colegas sobre a jornada deles. {link}',
+    id: 'fSrztQ',
     description: 'Description of the content of the Retrospective tab on the teams page.',
   },
 

--- a/src/components/Routine/RetrospectiveTab/Answers/AnswerContent/AnswerCards/HistoryAnswersCard/history-answers.tsx
+++ b/src/components/Routine/RetrospectiveTab/Answers/AnswerContent/AnswerCards/HistoryAnswersCard/history-answers.tsx
@@ -1,4 +1,4 @@
-import { Button, Circle, Divider, Flex, List, ListItem, Text } from '@chakra-ui/react'
+import { Button, Circle, Divider, Flex, List, ListItem, Text, VStack } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import { format, parseISO } from 'date-fns'
 import { useRouter } from 'next/router'
@@ -128,29 +128,34 @@ const HistoryAnswers = ({ answers }: HistoryAnswersProperties) => {
             )
           })}
         </List>
-        <Flex gap={3} width={28}>
-          <StyledButton
-            isDisabled={!previousRoutineAnswered.id}
-            onClick={() => handlePushToAnswer(previousRoutineAnswered)}
-          >
-            <ArrowRight
-              fill="new-gray.700"
+        <VStack>
+          <Flex gap={3} width={28}>
+            <StyledButton
+              isDisabled={!previousRoutineAnswered.id}
+              onClick={() => handlePushToAnswer(previousRoutineAnswered)}
+            >
+              <ArrowRight
+                fill="new-gray.700"
+                style={{ transform: 'rotate(180deg)' }}
+                desc={intl.formatMessage(messages.arrowRightIcon)}
+              />
+            </StyledButton>
+            <StyledButton
+              isDisabled={!lastRoutine.id}
               style={{ transform: 'rotate(180deg)' }}
-              desc={intl.formatMessage(messages.arrowRightIcon)}
-            />
-          </StyledButton>
-          <StyledButton
-            isDisabled={!lastRoutine.id}
-            style={{ transform: 'rotate(180deg)' }}
-            onClick={() => handlePushToAnswer(lastRoutine)}
-          >
-            <ArrowRight
-              fill="new-gray.700"
-              style={{ transform: 'rotate(180deg)' }}
-              desc={intl.formatMessage(messages.arrowLeftIcon)}
-            />
-          </StyledButton>
-        </Flex>
+              onClick={() => handlePushToAnswer(lastRoutine)}
+            >
+              <ArrowRight
+                fill="new-gray.700"
+                style={{ transform: 'rotate(180deg)' }}
+                desc={intl.formatMessage(messages.arrowLeftIcon)}
+              />
+            </StyledButton>
+          </Flex>
+          <Text color="new-gray.600" fontSize={12}>
+            {intl.formatMessage(messages.navigateAnswersHistoryMenu)}
+          </Text>
+        </VStack>
       </Flex>
     </AnswerCardBase>
   )

--- a/src/components/Routine/RetrospectiveTab/Answers/AnswerContent/AnswerCards/HistoryAnswersCard/messages.ts
+++ b/src/components/Routine/RetrospectiveTab/Answers/AnswerContent/AnswerCards/HistoryAnswersCard/messages.ts
@@ -5,6 +5,7 @@ type HistoryAnswersCardMessages =
   | 'historyAnswersCardTitle'
   | 'arrowRightIcon'
   | 'arrowLeftIcon'
+  | 'navigateAnswersHistoryMenu'
 
 export default defineMessages<HistoryAnswersCardMessages>({
   graphicIconDesc: {
@@ -31,5 +32,12 @@ export default defineMessages<HistoryAnswersCardMessages>({
       'Um ícone de seta para a esquerda que indica que o usuário pode retroceder no histórico para conferir outras respostas da rotina.',
     id: 'h6wsCP',
     description: 'The alternative text explaining our graphic icon',
+  },
+
+  navigateAnswersHistoryMenu: {
+    defaultMessage: 'Respostas',
+    id: 'UHZQHg',
+    description:
+      'This message appears in the subtitle of the menu that allows users to browse responses through the history.',
   },
 })

--- a/src/components/Routine/RetrospectiveTab/Answers/AnswerContent/index.tsx
+++ b/src/components/Routine/RetrospectiveTab/Answers/AnswerContent/index.tsx
@@ -1,11 +1,16 @@
 import { Box, Divider, VStack } from '@chakra-ui/react'
 import React, { useEffect } from 'react'
+import { useIntl } from 'react-intl'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
 
+import CustomMenuOptions, { Option } from 'src/components/Base/MenuOptions'
+import { useDeleteRoutineAnswer } from 'src/components/Routine/hooks/deleteAnswer/delete-routine-answer'
 import { commentsAtom } from 'src/state/recoil/comments/comments'
 import { answerDetailedAtom } from 'src/state/recoil/routine/answer'
+import meAtom from 'src/state/recoil/user/me'
 
 import { AnswerType } from '../../retrospective-tab-content'
+import messages from '../messages'
 
 import RoutineAnswerCard from './AnswerCards'
 import HistoryAnswers from './AnswerCards/HistoryAnswersCard/history-answers'
@@ -18,6 +23,13 @@ type AnswerContent = {
 const AnswerContent = ({ answerId }: AnswerContent) => {
   const answerDetailed = useRecoilValue(answerDetailedAtom)
   const setComments = useSetRecoilState(commentsAtom)
+  const intl = useIntl()
+
+  const userID = useRecoilValue(meAtom)
+
+  const { deleteRoutineAnswer } = useDeleteRoutineAnswer()
+
+  const hasPermission = userID === answerDetailed.user.id
 
   useEffect(() => {
     setComments([])
@@ -25,15 +37,31 @@ const AnswerContent = ({ answerId }: AnswerContent) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answerId])
 
+  const menuOptions: Option[] = [
+    {
+      value: intl.formatMessage(messages.firstMenuOption),
+      onSelect: async () => deleteRoutineAnswer(answerId),
+    },
+  ]
+
   return (
     <>
       <UserAnswer user={answerDetailed.user} />
 
       <Divider borderColor="new-gray.400" />
 
-      <VStack align="flex-start" padding={10} pb={12}>
+      <VStack align="flex-start" px={12} py={10}>
         {answerDetailed.history.length > 0 && (
-          <Box>
+          <Box position="relative">
+            {hasPermission && (
+              <CustomMenuOptions
+                options={menuOptions}
+                right={-14}
+                legend={intl.formatMessage(messages.actionsMenuDescription)}
+                position="absolute"
+                gap={1}
+              />
+            )}
             <HistoryAnswers answers={answerDetailed.history} />
             {answerDetailed.answers.map((answer) => {
               return <RoutineAnswerCard key={answer.id} answerData={answer} />

--- a/src/components/Routine/RetrospectiveTab/Answers/answer-row.tsx
+++ b/src/components/Routine/RetrospectiveTab/Answers/answer-row.tsx
@@ -11,19 +11,12 @@ import { EventType } from 'src/state/hooks/useEvent/event-type'
 import { useEvent } from 'src/state/hooks/useEvent/hook'
 import useRelativeDate from 'src/state/hooks/useRelativeDate'
 
+import { AnswerSummary } from '../retrospective-tab-content'
+
 import messages from './messages'
 
-interface Answer {
-  id: string
-  name: string
-  picture: string
-  latestStatusReply: string
-  timestamp: Date
-  commentCount: number
-}
-
 interface AnswerRowComponentProperties {
-  answer: Answer
+  answer: AnswerSummary
 }
 
 const AnswerRowComponent = ({ answer }: AnswerRowComponentProperties) => {
@@ -35,7 +28,7 @@ const AnswerRowComponent = ({ answer }: AnswerRowComponentProperties) => {
 
   const { getEmoji } = useGetEmoji()
 
-  const setActiveAnswer = (answerId: Answer['id']) => {
+  const setActiveAnswer = (answerId: AnswerSummary['id']) => {
     if (answerId) {
       router.push(
         {

--- a/src/components/Routine/RetrospectiveTab/Answers/answer-row.tsx
+++ b/src/components/Routine/RetrospectiveTab/Answers/answer-row.tsx
@@ -23,8 +23,9 @@ const AnswerRowComponent = ({ answer }: AnswerRowComponentProperties) => {
   const intl = useIntl()
   const { dispatch } = useEvent(EventType.ROUTINE_ANSWER_ROW_CLICK)
   const router = useRouter()
-  const [formattedRelativeDate] = useRelativeDate(new Date(answer.timestamp))
-  const isTheDateToday = isToday(new Date(answer.timestamp))
+  const [formattedRelativeDate] = useRelativeDate(new Date(answer.timestamp ?? ''))
+
+  const isTheDateToday = answer.timestamp ? isToday(new Date(answer.timestamp)) : undefined
 
   const { getEmoji } = useGetEmoji()
 

--- a/src/components/Routine/RetrospectiveTab/Answers/index.tsx
+++ b/src/components/Routine/RetrospectiveTab/Answers/index.tsx
@@ -23,6 +23,8 @@ import {
 import meAtom from 'src/state/recoil/user/me'
 import selectUser from 'src/state/recoil/user/selector'
 
+import { AnswerSummary } from '../retrospective-tab-content'
+
 import AnswerRowComponent from './answer-row'
 import messages from './messages'
 
@@ -32,16 +34,6 @@ interface AnswersComponentProperties {
   after: Date
   before: Date
   week: number
-}
-
-interface AnswerSummary {
-  id: string
-  userId: string
-  name: string
-  picture: string
-  latestStatusReply: string
-  timestamp: Date
-  commentCount: number
 }
 
 const ScrollableItem = getScrollableItem()

--- a/src/components/Routine/RetrospectiveTab/Answers/messages.ts
+++ b/src/components/Routine/RetrospectiveTab/Answers/messages.ts
@@ -12,6 +12,8 @@ type AnswersMessage =
   | 'hourPrefix'
   | 'noAnswerText'
   | 'weekText'
+  | 'actionsMenuDescription'
+  | 'firstMenuOption'
 
 export default defineMessages<AnswersMessage>({
   arrowLeftIconDescription: {
@@ -70,5 +72,17 @@ export default defineMessages<AnswersMessage>({
     defaultMessage: 'Semana',
     id: 'IfVw1+',
     description: 'The text that appears at the week description',
+  },
+
+  actionsMenuDescription: {
+    defaultMessage: 'Opções',
+    id: 'Jw9V43',
+    description: 'This message appears how description to menu action options',
+  },
+
+  firstMenuOption: {
+    defaultMessage: 'Apagar esta resposta',
+    id: 'lvyLZA',
+    description: 'This message is used in the button where the user can delete a routine response.',
   },
 })

--- a/src/components/Routine/RetrospectiveTab/RoutinesOverview/index.tsx
+++ b/src/components/Routine/RetrospectiveTab/RoutinesOverview/index.tsx
@@ -3,12 +3,14 @@
 import { Box, Divider, Flex, GridItem, Text } from '@chakra-ui/react'
 import { addMinutes, format, isSameDay, parseISO } from 'date-fns'
 import pt from 'date-fns/locale/pt'
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect } from 'react'
 import { useIntl } from 'react-intl'
+import { useRecoilState } from 'recoil'
 
 import { ServicesContext } from 'src/components/Base/ServicesProvider/services-provider'
 import SuitcaseIcon from 'src/components/Icon/Suitcase'
 import { useGetEmoji } from 'src/components/Routine/hooks'
+import { overviewDataAtom } from 'src/state/recoil/routine/overview-data'
 
 import { AreaRadialChart } from '../../../Base/Charts/index'
 
@@ -49,7 +51,7 @@ const RoutinesOverview = ({ teamId, after, before, week }: RoutinesOverviewPrope
   const intl = useIntl()
   const { getEmoji } = useGetEmoji()
   const { servicesPromise } = useContext(ServicesContext)
-  const [answersOverview, setAnswersOverview] = useState<OverviewData | undefined>()
+  const [answersOverview, setAnswersOverview] = useRecoilState(overviewDataAtom)
 
   const getAnswersOverview = useCallback(async () => {
     const { routines } = await servicesPromise

--- a/src/components/Routine/RetrospectiveTab/retrospective-tab-content.tsx
+++ b/src/components/Routine/RetrospectiveTab/retrospective-tab-content.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react'
 import { format, parse, differenceInDays } from 'date-fns'
 import { useRouter } from 'next/router'
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { useRecoilState, useRecoilValue } from 'recoil'
 
@@ -22,6 +22,7 @@ import messages from 'src/components/Page/Team/Tabs/content/messages'
 import { NotificationSettingsModal } from 'src/components/Routine/NotificationSettings'
 import { Team } from 'src/components/Team/types'
 import { GraphQLEffect } from 'src/components/types'
+import { answerSummaryAtom } from 'src/state/recoil/routine/answer-summary'
 import {
   getRoutineDateRangeDateFormat,
   routineDatesRangeAtom,
@@ -50,21 +51,21 @@ interface RetrospectiveTabContentProperties {
   teamId: Team['id']
 }
 
-interface AnswerSummary {
-  id: string
+export interface AnswerSummary {
+  id?: string
   userId: string
   name: string
   picture: string
-  latestStatusReply: string
-  timestamp: Date
-  commentCount: number
+  latestStatusReply?: string
+  timestamp?: Date
+  commentCount?: number
 }
 
 const RetrospectiveTabContent = ({ teamId }: RetrospectiveTabContentProperties) => {
   const intl = useIntl()
   const router = useRouter()
   const { servicesPromise } = useContext(ServicesContext)
-  const [answersSummary, setAnswersSummary] = useState<AnswerSummary[]>([])
+  const [answersSummary, setAnswersSummary] = useRecoilState(answerSummaryAtom)
   const team = useRecoilValue(teamAtomFamily(teamId))
   const canEditTeam = team?.policy?.update === GraphQLEffect.ALLOW
   const { teamOptedOut, toggleDisabledTeam } = useRoutineNotificationSettings(teamId)

--- a/src/components/Routine/RetrospectiveTab/retrospective-tab-content.tsx
+++ b/src/components/Routine/RetrospectiveTab/retrospective-tab-content.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   IconButton,
   useDisclosure,
+  Link,
 } from '@chakra-ui/react'
 import { format, parse, differenceInDays } from 'date-fns'
 import { useRouter } from 'next/router'
@@ -16,6 +17,7 @@ import { useIntl } from 'react-intl'
 import { useRecoilState, useRecoilValue } from 'recoil'
 
 import { ServicesContext } from 'src/components/Base/ServicesProvider/services-provider'
+import { CircleArrowRight } from 'src/components/Icon'
 import CircleIcon from 'src/components/Icon/Circle'
 import GearIcon from 'src/components/Icon/Gear'
 import messages from 'src/components/Page/Team/Tabs/content/messages'
@@ -152,7 +154,27 @@ const RetrospectiveTabContent = ({ teamId }: RetrospectiveTabContentProperties) 
             alignItems="center"
             justifyContent="center"
           >
-            {intl.formatMessage(messages.tabRetrospectivePageDescription)}
+            {intl.formatMessage(messages.tabRetrospectivePageDescription, {
+              link: (
+                <Link
+                  isExternal
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  ml={1}
+                  gap={1}
+                  target="_blank"
+                  href="https://www.loom.com/share/4e69b3a0269a4b60ab2f4a290c64abae"
+                  verticalAlign="middle"
+                >
+                  {intl.formatMessage(messages.learnMoreRetrospectiveMessage)}
+                  <CircleArrowRight
+                    alignContent="center"
+                    desc={intl.formatMessage(messages.learnMoreRetrospectiveIcon)}
+                  />
+                </Link>
+              ),
+            })}
           </Text>
         </Stack>
         {canEditTeam ? (

--- a/src/components/Routine/hooks/deleteAnswer/delete-routine-answer.tsx
+++ b/src/components/Routine/hooks/deleteAnswer/delete-routine-answer.tsx
@@ -1,0 +1,77 @@
+import { useToast } from '@chakra-ui/react'
+import { useRouter } from 'next/router'
+import { useContext } from 'react'
+import { useIntl } from 'react-intl'
+import { useRecoilState, useSetRecoilState } from 'recoil'
+
+import { ServicesContext } from 'src/components/Base/ServicesProvider/services-provider'
+import { useRoutineTab } from 'src/components/Routine/hooks/getRoutineTab/'
+import { answerSummaryAtom } from 'src/state/recoil/routine/answer-summary'
+import { overviewDataAtom } from 'src/state/recoil/routine/overview-data'
+
+import { OverviewData } from '../../RetrospectiveTab/RoutinesOverview'
+import { AnswerType } from '../../RetrospectiveTab/retrospective-tab-content'
+import { usePendingRoutines } from '../getPendingRoutine'
+
+import messages from './messages'
+
+export const useDeleteRoutineAnswer = () => {
+  const { servicesPromise } = useContext(ServicesContext)
+  const { getPendingRoutines } = usePendingRoutines()
+  const intl = useIntl()
+
+  const toaster = useToast()
+  const router = useRouter()
+
+  const queryPath = router.query?.id
+  const [id] = Array.isArray(queryPath) ? queryPath : [queryPath]
+  const [answerSummary, setAnswerSummary] = useRecoilState(answerSummaryAtom)
+  const setRoutineOverviewData = useSetRecoilState(overviewDataAtom)
+
+  const routineTabName = useRoutineTab()
+
+  const deleteRoutineAnswer = async (answerId: AnswerType['id']) => {
+    const { routines } = await servicesPromise
+
+    const refetchRoutineData = async () => {
+      const answerSummaryFiltered = answerSummary.map((answer) =>
+        answer.id === answerId
+          ? {
+              userId: answer.userId,
+              name: answer.name,
+              picture: answer.picture,
+            }
+          : answer,
+      )
+      setAnswerSummary(answerSummaryFiltered)
+
+      const { data: answersOverview } = await routines.get<OverviewData>(
+        `/answers/overview/${id ?? ''}`,
+        {
+          params: { includeSubteams: false },
+        },
+      )
+      if (answersOverview) setRoutineOverviewData(answersOverview)
+      await getPendingRoutines()
+    }
+
+    try {
+      await routines.delete(`/answer/${answerId}`)
+
+      await refetchRoutineData()
+      toaster({
+        title: intl.formatMessage(messages.successDeleteToastMessage),
+        status: 'success',
+      })
+
+      if (id) router.push(`/explore/${id}?activeTab=${routineTabName}`)
+    } catch {
+      toaster({
+        title: intl.formatMessage(messages.warningDeleteToastMessage),
+        status: 'error',
+      })
+    }
+  }
+
+  return { deleteRoutineAnswer }
+}

--- a/src/components/Routine/hooks/deleteAnswer/messages.ts
+++ b/src/components/Routine/hooks/deleteAnswer/messages.ts
@@ -1,0 +1,18 @@
+import { defineMessages } from 'react-intl'
+
+type deleteRoutineAnswerMessages = 'successDeleteToastMessage' | 'warningDeleteToastMessage'
+
+export default defineMessages<deleteRoutineAnswerMessages>({
+  successDeleteToastMessage: {
+    defaultMessage: 'Resposta deletada com sucesso!',
+    id: 'sX1k+9',
+    description:
+      'This message appears in a toast indicating success in deleting a routines response.',
+  },
+  warningDeleteToastMessage: {
+    defaultMessage: 'Não foi possível deletar a resposta!',
+    id: 'uxjg0W',
+    description:
+      'This message appears in a toast indicating that it was not possible to delete a routines response.',
+  },
+})

--- a/src/components/Routine/hooks/getPendingRoutine/get-pending-routines.tsx
+++ b/src/components/Routine/hooks/getPendingRoutine/get-pending-routines.tsx
@@ -19,5 +19,5 @@ export const usePendingRoutines = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return routines
+  return { routines, getPendingRoutines }
 }

--- a/src/components/Routine/hooks/setComment/set-comment.tsx
+++ b/src/components/Routine/hooks/setComment/set-comment.tsx
@@ -19,7 +19,6 @@ export const useCreateComment = () => {
     const { comments } = await servicesPromise
     if (entity) {
       const { data: createdComment } = await comments.post<Comment>(`/comments/${entity}`, {
-        entity,
         content,
       })
       setRoutineComment((previousComments) => [...previousComments, createdComment])

--- a/src/state/recoil/routine/answer-summary.ts
+++ b/src/state/recoil/routine/answer-summary.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil'
+
+import { AnswerSummary } from 'src/components/Routine/RetrospectiveTab/retrospective-tab-content'
+
+import { PREFIX } from './constants'
+
+export const answerSummaryAtom = atom<AnswerSummary[]>({
+  key: `${PREFIX}::ANSWER_SUMMARY`,
+  default: [],
+})

--- a/src/state/recoil/routine/overview-data.ts
+++ b/src/state/recoil/routine/overview-data.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil'
+
+import { OverviewData } from 'src/components/Routine/RetrospectiveTab/RoutinesOverview'
+
+import { PREFIX } from './constants'
+
+export const overviewDataAtom = atom<OverviewData | undefined>({
+  key: `${PREFIX}::OVERVIEW_DATA`,
+  default: undefined,
+})


### PR DESCRIPTION
## 🎢 Motivation

Allow a user to delete their response from routines.

## 🔧 Solution

* Implementation of an action menu where the user selects the button to delete the routine.
* The button should only appear if the user owns the answer.
* When deleting a response, the routine data is updated, and the user can respond again.

## 🚨  Testing

[A brief description of how the reviewer can test my PR.](https://drive.google.com/file/d/1N6SgtAVw7W0zh4cfIKoOVmrZLWNQ1J07/view?usp=share_link)

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-464`](https://getbud.atlassian.net/jira/software/projects/BUD22/boards/16?selectedIssue=BUD22-464)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`routines-microservice#93`](https://github.com/budproj/routines-microservice/pull/93)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
