### PR TITLE
feat(notices/banner)

### DIFF
--- a/src/components/Base/NoticesBanner/index.tsx
+++ b/src/components/Base/NoticesBanner/index.tsx
@@ -5,6 +5,8 @@ import { useIntl } from 'react-intl'
 import { useRecoilValue } from 'recoil'
 
 import { useRoutineTab } from 'src/components/Routine/hooks/getRoutineTab'
+import { EventType } from 'src/state/hooks/useEvent/event-type'
+import { useEvent } from 'src/state/hooks/useEvent/hook'
 import useLocalStorage from 'src/state/hooks/useLocalStorage/hook'
 import meAtom from 'src/state/recoil/user/me'
 import selectUser from 'src/state/recoil/user/selector'
@@ -16,6 +18,7 @@ const storageKey = 'Bud@new-feature'
 const NoticesBanner = () => {
   const { get, register } = useLocalStorage()
   const intl = useIntl()
+  const { dispatch: learnMoreClick } = useEvent(EventType.LEARN_MORE_BANNER_NOTICES_CLICK)
 
   const routineTabName = useRoutineTab()
   const router = useRouter()
@@ -41,8 +44,9 @@ const NoticesBanner = () => {
   }, [get])
 
   const handleRedirect = useCallback(() => {
+    learnMoreClick({})
     router.push(`/explore/${user?.companies?.edges[0]?.node.id ?? ''}?activeTab=${routineTabName}`)
-  }, [router, routineTabName, user?.companies?.edges])
+  }, [learnMoreClick, router, routineTabName, user?.companies?.edges])
 
   const handleCloseBanner = useCallback(() => {
     register(storageKey, false)

--- a/src/components/Routine/RetrospectiveTab/Comments/CommentCard/index.tsx
+++ b/src/components/Routine/RetrospectiveTab/Comments/CommentCard/index.tsx
@@ -74,7 +74,7 @@ const CommentCard = ({ id, userId, timestamp, comment, entity }: CommentCard) =>
             textAlign="right"
           />
         </Flex>
-        <Text wordBreak="break-all" fontSize={14} color="new-gray.900">
+        <Text wordBreak="break-word" fontSize={14} color="new-gray.900">
           {commentText}
         </Text>
         <Button

--- a/src/state/hooks/useEvent/event-type.ts
+++ b/src/state/hooks/useEvent/event-type.ts
@@ -33,6 +33,7 @@ export enum EventType {
   TOGGLE_ROUTINE_REMINDER_CLICK = 'ToggleRoutineReminderClick',
   ANSWER_NOW_FORM_CLICK = 'AnswerNowFormClick',
   COMMENT_IN_ROUTINE_ANSWER_CLICK = 'CommentInRoutineAnswerClick',
+  LEARN_MORE_BANNER_NOTICES_CLICK = 'LearnMoreBannerNoticesClick',
   MENTION_IN_ROUTINE_ANSWER_CLICK = 'MentionInRoutineAnswerClick',
   METRIC_TEAM_ROW_CLICK = 'MetricTeamRowClick',
 }

--- a/src/state/hooks/useEvent/event.ts
+++ b/src/state/hooks/useEvent/event.ts
@@ -12,6 +12,7 @@ import { DeletedKeyResultCheckMarkEventData } from './events/deleted-key-result-
 import { DeletedPersonalTaskEventData } from './events/deleted-personal-task'
 import { KeyResultCreateChecklistEventData } from './events/key-result-create-checklist'
 import { KeyResultProgressChartViewEventData } from './events/key-result-progress-chart-view'
+import { LearnMoreBannerNoticesClickData } from './events/learn-more-banner-notices-click-data'
 import { MentionInRoutineAnswerClickData } from './events/mention-in-routine-click-data'
 import { MetricTeamRowClickData } from './events/metric-team-row-click-data'
 import { NotificationBellData } from './events/notification-bell-data'
@@ -73,4 +74,5 @@ export type Event = {
   [EventType.COMMENT_IN_ROUTINE_ANSWER_CLICK]: CommentInRoutineAnswerClickData
   [EventType.MENTION_IN_ROUTINE_ANSWER_CLICK]: MentionInRoutineAnswerClickData
   [EventType.METRIC_TEAM_ROW_CLICK]: MetricTeamRowClickData
+  [EventType.LEARN_MORE_BANNER_NOTICES_CLICK]: LearnMoreBannerNoticesClickData
 }

--- a/src/state/hooks/useEvent/events/learn-more-banner-notices-click-data.ts
+++ b/src/state/hooks/useEvent/events/learn-more-banner-notices-click-data.ts
@@ -1,0 +1,3 @@
+import { BaseEventData } from './base-event'
+
+export interface LearnMoreBannerNoticesClickData extends BaseEventData {}


### PR DESCRIPTION
## 🎢 Motivation

- Creating a news banner to notify a Retrospective feature.

## 🔧 Solution

- Foi implementado um componente que é renderizado acima dos conteúdos das páginas, em _app. 
- O banner é setado como false no localstorage quando o usuário o fecha.

## 🚨  Testing

A brief description of how the reviewer can test my PR.

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-EDP38`](https://getbud.atlassian.net/browse/EPD-38)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
