### PR TITLE
[EPD-48] feat(components/Workspace/CreateForm): create routines settings

### DIFF
--- a/src/components/Workspace/CreateForm/wrapper.tsx
+++ b/src/components/Workspace/CreateForm/wrapper.tsx
@@ -5,6 +5,8 @@ import { Form, Formik } from 'formik'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
+import { postCreateTeamSettings } from 'src/state/recoil/routine/post-create-team-settings'
+
 import { LOCALE } from '../../../config'
 import { TEAM_GENDER } from '../../Team/constants'
 import { USER_GENDER } from '../../User/constants'
@@ -54,6 +56,7 @@ const initialValues: CreateWorkspaceFormValues = {
 export const CreateFormWrapper = () => {
   const intl = useIntl()
   const toast = useToast()
+  const createTeamSettings = postCreateTeamSettings()
   const [addConsultant, { loading: addingConsultant }] = useMutation(queries.ADD_CONSULTANT, {
     onCompleted: () => {
       toast({
@@ -70,6 +73,8 @@ export const CreateFormWrapper = () => {
       })
     },
     onCompleted: async (data) => {
+      void createTeamSettings(data.createWorkspace.id)
+
       void addConsultant({
         variables: {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/src/state/recoil/routine/post-create-team-settings.ts
+++ b/src/state/recoil/routine/post-create-team-settings.ts
@@ -1,0 +1,15 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useContext } from 'react'
+
+import { ServicesContext } from 'src/components/Base/ServicesProvider/services-provider'
+import { Team } from 'src/components/Team/types'
+
+export const postCreateTeamSettings = () => {
+  const { servicesPromise } = useContext(ServicesContext)
+
+  return async (companyId: Team['id']) => {
+    const { routines } = await servicesPromise
+
+    await routines.post(`/settings/${companyId}`, {})
+  }
+}


### PR DESCRIPTION
## 🎢 Motivation

Ao criar um novo time, as configurações de rotinas não eram criadas.

## 🔧 Solution

Ao preencher o formulario de novo workspace, fazer um request para o microserviço de rotinas.

## 🚨  Testing

Navegar para `/new-workspace` e preencher o formulario. O request para o microserviço de rotinas deve ser um sucesso. Verificar se o registro no banco do microserviço é criado e se a mensagem do nats para o microserviço de scheduling é enviada.

## 🃏 Task Card

Link to issue on Jira

- [`EPD-48`](https://getbud.atlassian.net/browse/EPD-48)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- budproj/routines-microservice#102

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [x] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [x] Diego
