### PR TITLE
Feat/tasks exclude new tag

### DIFF
--- a/src/components/Page/Team/Tabs/tabs-menu.tsx
+++ b/src/components/Page/Team/Tabs/tabs-menu.tsx
@@ -73,26 +73,7 @@ const TabsMenu = ({ teamId }: TabsMenuProperties) => {
               dispatchTaskManagerTabClick({})
             }}
           >
-            <div
-              id="retrospective-tab"
-              style={{
-                display: 'flex',
-              }}
-            >
-              {intl.formatMessage(messages.tasksTeamTab)}
-              <Tag
-                size="md"
-                color="white"
-                borderColor="current"
-                border="1px solid"
-                lineHeight="0px"
-                fontWeight="semibold"
-                bg="brand.500"
-                ml={2}
-              >
-                {intl.formatMessage(tabMessages.newItem)}
-              </Tag>
-            </div>
+            {intl.formatMessage(messages.tasksTeamTab)}
           </StyledTab>
           <Box width="1px" bg="new-gray.500" />
         </>

--- a/src/components/Page/Team/Tabs/tabs-menu.tsx
+++ b/src/components/Page/Team/Tabs/tabs-menu.tsx
@@ -1,10 +1,9 @@
-import { Box, Stack, Tab, TabList, Tag } from '@chakra-ui/react'
+import { Box, Stack, Tab, TabList } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import React from 'react'
 import { useIntl } from 'react-intl'
 
-import tabMessages from 'src/components/Base/MainAppBar/messages'
 import { Team } from 'src/components/Team/types'
 import { EventType } from 'src/state/hooks/useEvent/event-type'
 import { useEvent } from 'src/state/hooks/useEvent/hook'


### PR DESCRIPTION
## 🎢 Motivation

Exclude tag new from tasks tab, since it`s not a new feature anymore.

## 🔧 Solution

I gone to the tabs component and exclude the lines that create the tag. 

## 🚨  Testing

1. Open bud.
2. Go to a team. 
3. look at tabs.

## 🃏 Task Card

[notion](https://www.notion.so/budops/28fc5005cf3340f68de1468b2fd83b37?v=c01d6b713e204f1f97f8ed3a2a11b464&p=3cc5462b3c204f62b7db492c805f3800&pm=s)

## 🍩 Validation

### Canary

- [ ] Marcel

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
