### PR TITLE
Fix: comments loading before keyresult.

### DIFF
--- a/src/components/KeyResult/Single/Drawer/Body/body.tsx
+++ b/src/components/KeyResult/Single/Drawer/Body/body.tsx
@@ -79,12 +79,14 @@ const KeyResultDrawerBody = ({
       <Portal containerRef={timelinePortalReference}>
         {isDraft && <KeyResultHistory />}
         <Box px={8} pt={4}>
-          <KeyResultSectionTimeline
-            isDraft={isDraft}
-            keyResultID={keyResultID}
-            scrollTarget={SCROLLBAR_ID}
-            newCheckInValue={newCheckInValue}
-          />
+          {keyResult && (
+            <KeyResultSectionTimeline
+              isDraft={isDraft}
+              keyResultID={keyResultID}
+              scrollTarget={SCROLLBAR_ID}
+              newCheckInValue={newCheckInValue}
+            />
+          )}
         </Box>
       </Portal>
       <Stack

--- a/src/components/KeyResult/Single/Sections/Timeline/timeline.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/timeline.tsx
@@ -77,8 +77,6 @@ const KeyResultSectionTimeline = ({
     if (onEntryDelete) onEntryDelete(entryType)
   }
 
-  console.log({ timeline })
-
   return (
     <Flex direction="column" gridGap={4}>
       {!isDraft && (


### PR DESCRIPTION
## 🎢 Motivation

Comentários não carregam em link para KR

## 🔧 Solution

Comments (timeline) were loading before key result.

## 🚨  Testing

**Quando sou marcado em um KR que não sou responsável nem apoio, sou direcionado para o link abaixo que me leva agora para a página do time, porém a sidebar do KR não carrega o conteúdo (comenatários e check-ins):**
https://app.getbud.co/explore/f717b12f-2cc0-45c7-8f35-2b3f4ae5e65c?keyResultId=0ee2bc3f-2aa3-44d2-9974-f521ac28c0cc&utm_source=bud&utm_medium=email&utm_campaign=notification&utm_content=mention

![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/310853d1-a521-4133-8714-620c7b36b6bb/cc1855f4-fe6e-47bb-a9d4-c2d9c2b30688/image.png)

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-123`](https://)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
