### PR TITLE
fix: mouse events from key result drawer not working

### DIFF
--- a/src/components/Base/KeyResultListing/index.tsx
+++ b/src/components/Base/KeyResultListing/index.tsx
@@ -11,13 +11,14 @@ import {
 } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import React, { memo, useCallback, useEffect } from 'react'
-import { useSetRecoilState } from 'recoil'
+import { useSetRecoilState, useRecoilState } from 'recoil'
 
 import KeyResultList from 'src/components/KeyResult/List'
 import { KEY_RESULT_LIST_COLUMN } from 'src/components/KeyResult/List/Body/Columns/constants'
 import { KEY_RESULT_LIST_TYPE } from 'src/components/KeyResult/List/constants'
 import { KeyResult } from 'src/components/KeyResult/types'
 import { keyResultReadDrawerOpenedKeyResultID } from 'src/state/recoil/key-result/drawers/read/opened-key-result-id'
+import { isKeyResultListOpenAtom } from 'src/state/recoil/key-result/key-result-list'
 
 export interface KeyResultModalListingProperties {
   isOpen: boolean
@@ -68,107 +69,116 @@ export const KeyResultListingModal = memo(
     onClose,
   }: KeyResultModalListingProperties) => {
     const setOpenDrawer = useSetRecoilState(keyResultReadDrawerOpenedKeyResultID)
+    const [ isHidding, setHideModal ] = useRecoilState(isKeyResultListOpenAtom);
 
     useEffect(() => {
       if (dispatchEvent) dispatchEvent()
     }, [dispatchEvent])
 
-    const onLineClick = useCallback((id: KeyResult['id']) => setOpenDrawer(id), [setOpenDrawer])
+    const onLineClick = useCallback(
+      (id: KeyResult['id']) => {
+        setOpenDrawer(id);
+        setHideModal(true);
+      }, [setOpenDrawer, setHideModal])
 
     return (
-      <Modal
-        isOpen={isOpen}
-        returnFocusOnClose={false}
-        size="100%"
-        autoFocus={false}
-        onClose={onClose}
-      >
-        <ModalOverlay />
-        <StyledModal>
-          <ModalBody p="40px">
-            <Flex mb={12} justifyContent="space-between" alignItems="center">
-              <Heading color="new-gray.900" fontWeight={500} as="h3" size="lg">
-                {modalHeadingTitle}
-              </Heading>
-              <ModalCloseButton
-                bg="black.100"
-                color="new-gray.600"
-                borderRadius="50%"
-                position="relative"
-                top="0"
-              />
-            </Flex>
+      <>
+      {isHidding === false && (
+        <Modal
+          isOpen={isOpen}
+          returnFocusOnClose={false}
+          size="100%"
+          autoFocus={false}
+          onClose={onClose}
+        >
+          <ModalOverlay />
+          <StyledModal>
+            <ModalBody p="40px">
+              <Flex mb={12} justifyContent="space-between" alignItems="center">
+                <Heading color="new-gray.900" fontWeight={500} as="h3" size="lg">
+                  {modalHeadingTitle}
+                </Heading>
+                <ModalCloseButton
+                  bg="black.100"
+                  color="new-gray.600"
+                  borderRadius="50%"
+                  position="relative"
+                  top="0"
+                />
+              </Flex>
 
-            <StyledTableWrapper>
-              <KeyResultList
-                type={KEY_RESULT_LIST_TYPE.STATIC}
-                keyResultIDs={keyResultIds}
-                isLoading={isLoading}
-                hasMoreKeyResults={showNextPageButton}
-                templateColumns="1.5fr 1fr 100px 80px 1fr"
-                borderColor="new-gray.400"
-                flex="1"
-                headProperties={{
-                  [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
-                    hidden: false,
-                  },
-                  [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
-                    hidden: false,
-                  },
-                  [KEY_RESULT_LIST_COLUMN.TEAM]: {
-                    hidden: false,
-                  },
-                  [KEY_RESULT_LIST_COLUMN.OWNER]: {
-                    hidden: false,
-                  },
-                  [KEY_RESULT_LIST_COLUMN.OBJECTIVE]: {
-                    hidden: false,
-                  },
-                }}
-                columns={[
-                  KEY_RESULT_LIST_COLUMN.KEY_RESULT,
-                  KEY_RESULT_LIST_COLUMN.PROGRESS,
-                  KEY_RESULT_LIST_COLUMN.TEAM,
-                  KEY_RESULT_LIST_COLUMN.OWNER,
-                  KEY_RESULT_LIST_COLUMN.OBJECTIVE,
-                ]}
-                bodyProperties={{
-                  [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
-                    withDynamicIcon: true,
-                    withLastUpdateInfo: true,
-                  },
-                  [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
-                    withConfidenceTag: true,
-                  },
-                }}
-                onLineClick={onLineClick}
-              />
-            </StyledTableWrapper>
-            <HStack width="100%" mt={10} gap={2} alignItems="center" justifyContent="flex-end">
-              {!isLoading && showPreviousPageButton && (
-                <Button
-                  bg="brand.500"
-                  color="white"
-                  _hover={{ backgroundColor: 'brand.300' }}
-                  onClick={loadPreviousKrsPage}
-                >
-                  Prev
-                </Button>
-              )}
-              {!isLoading && showNextPageButton && (
-                <Button
-                  bg="brand.500"
-                  color="white"
-                  _hover={{ backgroundColor: 'brand.300' }}
-                  onClick={loadNextKrsPage}
-                >
-                  Next
-                </Button>
-              )}
-            </HStack>
-          </ModalBody>
-        </StyledModal>
-      </Modal>
+              <StyledTableWrapper>
+                <KeyResultList
+                  type={KEY_RESULT_LIST_TYPE.STATIC}
+                  keyResultIDs={keyResultIds}
+                  isLoading={isLoading}
+                  hasMoreKeyResults={showNextPageButton}
+                  templateColumns="1.5fr 1fr 100px 80px 1fr"
+                  borderColor="new-gray.400"
+                  flex="1"
+                  headProperties={{
+                    [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
+                      hidden: false,
+                    },
+                    [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
+                      hidden: false,
+                    },
+                    [KEY_RESULT_LIST_COLUMN.TEAM]: {
+                      hidden: false,
+                    },
+                    [KEY_RESULT_LIST_COLUMN.OWNER]: {
+                      hidden: false,
+                    },
+                    [KEY_RESULT_LIST_COLUMN.OBJECTIVE]: {
+                      hidden: false,
+                    },
+                  }}
+                  columns={[
+                    KEY_RESULT_LIST_COLUMN.KEY_RESULT,
+                    KEY_RESULT_LIST_COLUMN.PROGRESS,
+                    KEY_RESULT_LIST_COLUMN.TEAM,
+                    KEY_RESULT_LIST_COLUMN.OWNER,
+                    KEY_RESULT_LIST_COLUMN.OBJECTIVE,
+                  ]}
+                  bodyProperties={{
+                    [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
+                      withDynamicIcon: true,
+                      withLastUpdateInfo: true,
+                    },
+                    [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
+                      withConfidenceTag: true,
+                    },
+                  }}
+                  onLineClick={onLineClick}
+                />
+              </StyledTableWrapper>
+              <HStack width="100%" mt={10} gap={2} alignItems="center" justifyContent="flex-end">
+                {!isLoading && showPreviousPageButton && (
+                  <Button
+                    bg="brand.500"
+                    color="white"
+                    _hover={{ backgroundColor: 'brand.300' }}
+                    onClick={loadPreviousKrsPage}
+                  >
+                    Prev
+                  </Button>
+                )}
+                {!isLoading && showNextPageButton && (
+                  <Button
+                    bg="brand.500"
+                    color="white"
+                    _hover={{ backgroundColor: 'brand.300' }}
+                    onClick={loadNextKrsPage}
+                  >
+                    Next
+                  </Button>
+                )}
+              </HStack>
+            </ModalBody>
+          </StyledModal>
+        </Modal>
+      )}
+      </>
     )
   },
 )

--- a/src/components/Base/KeyResultListing/index.tsx
+++ b/src/components/Base/KeyResultListing/index.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   Button,
   HStack,
+  Box,
 } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import React, { memo, useCallback, useEffect } from 'react'
@@ -84,103 +85,103 @@ export const KeyResultListingModal = memo(
     )
 
     return (
-      (isHidding && (
-        <Modal
-          isOpen={isOpen}
-          returnFocusOnClose={false}
-          size="100%"
-          autoFocus={false}
-          onClose={onClose}
-        >
-          <ModalOverlay />
-          <StyledModal>
-            <ModalBody p="40px">
-              <Flex mb={12} justifyContent="space-between" alignItems="center">
-                <Heading color="new-gray.900" fontWeight={500} as="h3" size="lg">
-                  {modalHeadingTitle}
-                </Heading>
-                <ModalCloseButton
-                  bg="black.100"
-                  color="new-gray.600"
-                  borderRadius="50%"
-                  position="relative"
-                  top="0"
-                />
-              </Flex>
+      <Box>
+        {!isHidding && (
+          <Modal
+            isOpen={isOpen}
+            returnFocusOnClose={false}
+            size="100%"
+            autoFocus={false}
+            onClose={onClose}
+          >
+            <ModalOverlay />
+            <StyledModal>
+              <ModalBody p="40px">
+                <Flex mb={12} justifyContent="space-between" alignItems="center">
+                  <Heading color="new-gray.900" fontWeight={500} as="h3" size="lg">
+                    {modalHeadingTitle}
+                  </Heading>
+                  <ModalCloseButton
+                    bg="black.100"
+                    color="new-gray.600"
+                    borderRadius="50%"
+                    position="relative"
+                    top="0"
+                  />
+                </Flex>
 
-              <StyledTableWrapper>
-                <KeyResultList
-                  type={KEY_RESULT_LIST_TYPE.STATIC}
-                  keyResultIDs={keyResultIds}
-                  isLoading={isLoading}
-                  hasMoreKeyResults={showNextPageButton}
-                  templateColumns="1.5fr 1fr 100px 80px 1fr"
-                  borderColor="new-gray.400"
-                  flex="1"
-                  headProperties={{
-                    [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
-                      hidden: false,
-                    },
-                    [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
-                      hidden: false,
-                    },
-                    [KEY_RESULT_LIST_COLUMN.TEAM]: {
-                      hidden: false,
-                    },
-                    [KEY_RESULT_LIST_COLUMN.OWNER]: {
-                      hidden: false,
-                    },
-                    [KEY_RESULT_LIST_COLUMN.OBJECTIVE]: {
-                      hidden: false,
-                    },
-                  }}
-                  columns={[
-                    KEY_RESULT_LIST_COLUMN.KEY_RESULT,
-                    KEY_RESULT_LIST_COLUMN.PROGRESS,
-                    KEY_RESULT_LIST_COLUMN.TEAM,
-                    KEY_RESULT_LIST_COLUMN.OWNER,
-                    KEY_RESULT_LIST_COLUMN.OBJECTIVE,
-                  ]}
-                  bodyProperties={{
-                    [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
-                      withDynamicIcon: true,
-                      withLastUpdateInfo: true,
-                    },
-                    [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
-                      withConfidenceTag: true,
-                    },
-                  }}
-                  onLineClick={onLineClick}
-                />
-              </StyledTableWrapper>
-              <HStack width="100%" mt={10} gap={2} alignItems="center" justifyContent="flex-end">
-                {!isLoading && showPreviousPageButton && (
-                  <Button
-                    bg="brand.500"
-                    color="white"
-                    _hover={{ backgroundColor: 'brand.300' }}
-                    onClick={loadPreviousKrsPage}
-                  >
-                    Prev
-                  </Button>
-                )}
-                {!isLoading && showNextPageButton && (
-                  <Button
-                    bg="brand.500"
-                    color="white"
-                    _hover={{ backgroundColor: 'brand.300' }}
-                    onClick={loadNextKrsPage}
-                  >
-                    Next
-                  </Button>
-                )}
-              </HStack>
-            </ModalBody>
-          </StyledModal>
-        </Modal>
-      )) ||
-      // eslint-disable-next-line unicorn/no-null
-      null
+                <StyledTableWrapper>
+                  <KeyResultList
+                    type={KEY_RESULT_LIST_TYPE.STATIC}
+                    keyResultIDs={keyResultIds}
+                    isLoading={isLoading}
+                    hasMoreKeyResults={showNextPageButton}
+                    templateColumns="1.5fr 1fr 100px 80px 1fr"
+                    borderColor="new-gray.400"
+                    flex="1"
+                    headProperties={{
+                      [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
+                        hidden: false,
+                      },
+                      [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
+                        hidden: false,
+                      },
+                      [KEY_RESULT_LIST_COLUMN.TEAM]: {
+                        hidden: false,
+                      },
+                      [KEY_RESULT_LIST_COLUMN.OWNER]: {
+                        hidden: false,
+                      },
+                      [KEY_RESULT_LIST_COLUMN.OBJECTIVE]: {
+                        hidden: false,
+                      },
+                    }}
+                    columns={[
+                      KEY_RESULT_LIST_COLUMN.KEY_RESULT,
+                      KEY_RESULT_LIST_COLUMN.PROGRESS,
+                      KEY_RESULT_LIST_COLUMN.TEAM,
+                      KEY_RESULT_LIST_COLUMN.OWNER,
+                      KEY_RESULT_LIST_COLUMN.OBJECTIVE,
+                    ]}
+                    bodyProperties={{
+                      [KEY_RESULT_LIST_COLUMN.KEY_RESULT]: {
+                        withDynamicIcon: true,
+                        withLastUpdateInfo: true,
+                      },
+                      [KEY_RESULT_LIST_COLUMN.PROGRESS]: {
+                        withConfidenceTag: true,
+                      },
+                    }}
+                    onLineClick={onLineClick}
+                  />
+                </StyledTableWrapper>
+                <HStack width="100%" mt={10} gap={2} alignItems="center" justifyContent="flex-end">
+                  {!isLoading && showPreviousPageButton && (
+                    <Button
+                      bg="brand.500"
+                      color="white"
+                      _hover={{ backgroundColor: 'brand.300' }}
+                      onClick={loadPreviousKrsPage}
+                    >
+                      Prev
+                    </Button>
+                  )}
+                  {!isLoading && showNextPageButton && (
+                    <Button
+                      bg="brand.500"
+                      color="white"
+                      _hover={{ backgroundColor: 'brand.300' }}
+                      onClick={loadNextKrsPage}
+                    >
+                      Next
+                    </Button>
+                  )}
+                </HStack>
+              </ModalBody>
+            </StyledModal>
+          </Modal>
+        )}
+      </Box>
     )
   },
 )

--- a/src/components/Base/KeyResultListing/index.tsx
+++ b/src/components/Base/KeyResultListing/index.tsx
@@ -69,7 +69,7 @@ export const KeyResultListingModal = memo(
     onClose,
   }: KeyResultModalListingProperties) => {
     const setOpenDrawer = useSetRecoilState(keyResultReadDrawerOpenedKeyResultID)
-    const [ isHidding, setHideModal ] = useRecoilState(isKeyResultListOpenAtom);
+    const [isHidding, setHideModal] = useRecoilState(isKeyResultListOpenAtom)
 
     useEffect(() => {
       if (dispatchEvent) dispatchEvent()
@@ -77,13 +77,14 @@ export const KeyResultListingModal = memo(
 
     const onLineClick = useCallback(
       (id: KeyResult['id']) => {
-        setOpenDrawer(id);
-        setHideModal(true);
-      }, [setOpenDrawer, setHideModal])
+        setOpenDrawer(id)
+        setHideModal(true)
+      },
+      [setOpenDrawer, setHideModal],
+    )
 
     return (
-      <>
-      {isHidding === false && (
+      (isHidding && (
         <Modal
           isOpen={isOpen}
           returnFocusOnClose={false}
@@ -177,8 +178,9 @@ export const KeyResultListingModal = memo(
             </ModalBody>
           </StyledModal>
         </Modal>
-      )}
-      </>
+      )) ||
+      // eslint-disable-next-line unicorn/no-null
+      null
     )
   },
 )

--- a/src/components/KeyResult/Single/Drawer/drawer.tsx
+++ b/src/components/KeyResult/Single/Drawer/drawer.tsx
@@ -17,14 +17,13 @@ import {
   isCheckListCollapseOpenAtom,
 } from 'src/state/recoil/key-result/checklist'
 import { keyResultReadDrawerOpenedKeyResultID } from 'src/state/recoil/key-result/drawers/read/opened-key-result-id'
+import { isKeyResultListOpenAtom } from 'src/state/recoil/key-result/key-result-list'
 import { createdByCheckInNotificationAtom } from 'src/state/recoil/notifications'
 
 import { EventType } from '../../../../state/hooks/useEvent/event-type'
 import { useEvent } from '../../../../state/hooks/useEvent/hook'
 
 import KeyResultDrawerContent from './content'
-
-import { isKeyResultListOpenAtom } from 'src/state/recoil/key-result/key-result-list'
 
 const timelineSelector = buildPartialSelector<KeyResult['timeline']>('timeline')
 const objectiveSelector = buildPartialSelector<KeyResult['objective']>('objective')
@@ -47,7 +46,6 @@ const KeyResultDrawer = () => {
   const setCreatedByNotification = useSetRecoilState(createdByCheckInNotificationAtom)
   const setIsChecklistOpen = useSetRecoilState(isCheckListCollapseOpenAtom)
   const setHiddingModal = useSetRecoilState(isKeyResultListOpenAtom)
-  
 
   const objective = useRecoilValue(objectiveSelector(keyResultID))
 

--- a/src/components/KeyResult/Single/Drawer/drawer.tsx
+++ b/src/components/KeyResult/Single/Drawer/drawer.tsx
@@ -24,6 +24,8 @@ import { useEvent } from '../../../../state/hooks/useEvent/hook'
 
 import KeyResultDrawerContent from './content'
 
+import { isKeyResultListOpenAtom } from 'src/state/recoil/key-result/key-result-list'
+
 const timelineSelector = buildPartialSelector<KeyResult['timeline']>('timeline')
 const objectiveSelector = buildPartialSelector<KeyResult['objective']>('objective')
 
@@ -44,6 +46,8 @@ const KeyResultDrawer = () => {
   const setIsCheckInModalOpen = useSetRecoilState(isCheckInModalOpenAtom)
   const setCreatedByNotification = useSetRecoilState(createdByCheckInNotificationAtom)
   const setIsChecklistOpen = useSetRecoilState(isCheckListCollapseOpenAtom)
+  const setHiddingModal = useSetRecoilState(isKeyResultListOpenAtom)
+  
 
   const objective = useRecoilValue(objectiveSelector(keyResultID))
 
@@ -56,6 +60,7 @@ const KeyResultDrawer = () => {
     setIsCheckInModalOpen(false)
     setIsChecklistOpen(false)
     setCreatedByNotification(false)
+    setHiddingModal(false)
   }
 
   const isOpen = Boolean(keyResultID)

--- a/src/state/recoil/key-result/key-result-list.ts
+++ b/src/state/recoil/key-result/key-result-list.ts
@@ -5,6 +5,6 @@ import { PREFIX } from './constants'
 const key = `${PREFIX}::CONTROL_LIST_MODAL`
 
 export const isKeyResultListOpenAtom = atom<boolean>({
-    key: `${key}::IS_OPEN`,
-    default: false,
+  key: `${key}::IS_OPEN`,
+  default: false,
 })

--- a/src/state/recoil/key-result/key-result-list.ts
+++ b/src/state/recoil/key-result/key-result-list.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil'
+
+import { PREFIX } from './constants'
+
+const key = `${PREFIX}::CONTROL_LIST_MODAL`
+
+export const isKeyResultListOpenAtom = atom<boolean>({
+    key: `${key}::IS_OPEN`,
+    default: false,
+})


### PR DESCRIPTION
## 🎢 Motivation

When you open Key Result from confidence list, the Key result modal had mouse interactions not working property.

## 🔧 Solution

It was needed to close modal of confidence key result list before open key result modal, opening those at same time create component focus conflict.

## 🚨  Testing

1. Open bud
2. Select one confidence level from dashboard
3. Select one Key result from the list
4. Try to up and down the page using mouse scroll

## 🃏 Task Card

- [`BUD22-123`](https://www.notion.so/budops/Bug-scroll-ao-abrir-um-kr-pelo-painel-eec593b2653d488f9ad154dd4723f984?pvs=4)

## 🔗 Related PRs

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
