### PR TITLE
Feat/key result actions edit

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -3099,6 +3099,10 @@
     "defaultMessage": "Personal Information",
     "description": "This title is displayed as the heading of the personal informations section in our user account settings page"
   },
+  "r2E/o2": {
+    "defaultMessage": "Edit this Key Result",
+    "description": "This button allow the user edit the Key Result."
+  },
   "R5fgoj": {
     "defaultMessage": "Next",
     "description": "This message appears on the button to move to the next question in the routines form."

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -3263,6 +3263,10 @@
     "defaultMessage": "Informações pessoais",
     "description": "This title is displayed as the heading of the personal informations section in our user account settings page"
   },
+  "r2E/o2": {
+    "defaultMessage": "Editar este Resultado-Chave",
+    "description": "This button allow the user edit the Key Result."
+  },
   "rDaIQ2": {
     "defaultMessage": "Retrospectiva da semana",
     "description": "The title of the routine reminder notification"

--- a/src/components/KeyResult/List/Body/Columns/Actions/actions.tsx
+++ b/src/components/KeyResult/List/Body/Columns/Actions/actions.tsx
@@ -15,6 +15,7 @@ import { GraphQLEffect } from '../../../../../types'
 
 import { CopyAction } from './copy-action'
 import { DeleteAction } from './delete-action'
+import EditAction from './edit-action'
 import messages from './messages'
 
 export interface KeyResultListBodyColumnActionsProperties
@@ -38,6 +39,10 @@ const KeyResultListBodyColumnActions = ({
     ? keyResult?.owner?.id === myID
     : keyResult?.policy?.delete === GraphQLEffect.ALLOW
 
+  const canEdit = isPersonalKr
+    ? keyResult?.owner?.id === myID
+    : keyResult?.policy?.update === GraphQLEffect.ALLOW
+
   return (
     <KeyResultListBodyColumnBase preventLineClick>
       <Menu placement="bottom-end" variant="action-list">
@@ -58,6 +63,7 @@ const KeyResultListBodyColumnActions = ({
         <MenuList>
           {keyResult?.title && <CopyAction keyResultTitle={keyResult.title} />}
           {canDelete && <DeleteAction id={id} onDelete={onDelete} />}
+          {canEdit && <EditAction id={id} />}
         </MenuList>
       </Menu>
     </KeyResultListBodyColumnBase>

--- a/src/components/KeyResult/List/Body/Columns/Actions/actions.tsx
+++ b/src/components/KeyResult/List/Body/Columns/Actions/actions.tsx
@@ -62,8 +62,8 @@ const KeyResultListBodyColumnActions = ({
         </MenuButton>
         <MenuList>
           {keyResult?.title && <CopyAction keyResultTitle={keyResult.title} />}
-          {canDelete && <DeleteAction id={id} onDelete={onDelete} />}
           {canEdit && <EditAction id={id} />}
+          {canDelete && <DeleteAction id={id} onDelete={onDelete} />}
         </MenuList>
       </Menu>
     </KeyResultListBodyColumnBase>

--- a/src/components/KeyResult/List/Body/Columns/Actions/edit-action.tsx
+++ b/src/components/KeyResult/List/Body/Columns/Actions/edit-action.tsx
@@ -1,0 +1,38 @@
+import { MenuItem } from '@chakra-ui/react'
+import React from 'react'
+import { useIntl } from 'react-intl'
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
+
+import { keyResultAtomFamily } from 'src/state/recoil/key-result'
+import { isEditingKeyResultIDAtom } from 'src/state/recoil/key-result/drawers/editing/is-editing-key-result-id'
+import { keyResultInsertDrawerObjectiveID } from 'src/state/recoil/key-result/drawers/insert/objective-id'
+import { keyResultReadDrawerOpenedKeyResultID } from 'src/state/recoil/key-result/drawers/read/opened-key-result-id'
+
+import messages from './messages'
+
+interface EditActionProperties {
+  id?: string
+}
+
+const EditAction = ({ id }: EditActionProperties) => {
+  const intl = useIntl()
+  const keyResult = useRecoilValue(keyResultAtomFamily(id))
+  const setKeyResultInsertDrawerObjectiveID = useSetRecoilState(keyResultInsertDrawerObjectiveID)
+  const isEditingKeyResultId = useSetRecoilState(isEditingKeyResultIDAtom)
+
+  const resetOpenDrawer = useResetRecoilState(keyResultReadDrawerOpenedKeyResultID)
+
+  const handleEditClick = () => {
+    setKeyResultInsertDrawerObjectiveID(id)
+    isEditingKeyResultId(keyResult?.id)
+    resetOpenDrawer()
+  }
+
+  return (
+    <MenuItem onClick={handleEditClick}>
+      {intl.formatMessage(messages.editButtonLabelMessage)}
+    </MenuItem>
+  )
+}
+
+export default EditAction

--- a/src/components/KeyResult/List/Body/Columns/Actions/messages.ts
+++ b/src/components/KeyResult/List/Body/Columns/Actions/messages.ts
@@ -12,6 +12,7 @@ type KeyResultListBodyColumnActionsMessage =
   | 'successfulCopyMessage'
   | 'copyButtonMessage'
   | 'optionsButtonDesc'
+  | 'editButtonLabelMessage'
 
 export default defineMessages<KeyResultListBodyColumnActionsMessage>({
   deleteIconDesc: {
@@ -81,5 +82,10 @@ export default defineMessages<KeyResultListBodyColumnActionsMessage>({
     id: 'XCDzMo',
     description:
       'This button allows you to choose an option that can allow you to copy the title ou exclude the KR.',
+  },
+  editButtonLabelMessage: {
+    defaultMessage: 'Editar este Resultado-Chave',
+    id: 'r2E/o2',
+    description: 'This button allow the user edit the Key Result.',
   },
 })


### PR DESCRIPTION
## 🎢 Motivation

Create button for key result actions tab that make edits

## 🔧 Solution

1. Create a new edit component
2. Set state from edit drawer
3. Set button for edit key result

## 🚨  Testing

1. Go to Team
2. Open OKR dropdown
3. Go to Key result actions
4. Choose Edit option
5. Edit Key result

## 🃏 Task Card

- [`BUD22`](https://www.notion.so/budops/Melhoria-Adicionar-um-bot-o-Editar-KR-no-bot-o-de-op-es-dos-KRs-407c5362ff54461b8c5f6de025aa05d9?pvs=4)


## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
