### PR TITLE
fix:Removed suggestion button and the functionallity

### DIFF
--- a/src/components/Page/Team/Tabs/content/board-tab-content.tsx
+++ b/src/components/Page/Team/Tabs/content/board-tab-content.tsx
@@ -80,21 +80,6 @@ const TasksTabContent = ({ teamId }: BoardTabContentProperties) => {
               onSearch={setSearchTaskInput}
             />
           </Box>
-          <a
-            href="https://bit.ly/sugestoestmanager"
-            target="_blank"
-            style={{ textDecoration: 'none' }}
-            rel="noreferrer"
-          >
-            <Button
-              bg="#525F7F"
-              color="black.50"
-              _hover={{ background: 'brand.400', color: 'black.50' }}
-              paddingY={2}
-            >
-              Dar sugestão
-            </Button>
-          </a>
           <Button
             bg={isArchivedBoard ? 'brand.500' : 'new-gray.300'}
             _hover={{ background: 'new-gray.400', color: 'new-gray.800' }}


### PR DESCRIPTION
## 🎢 Motivation

Need to remove a suggestion button in task tab content

## 🔧 Solution

Remove the functionality and the button display

## 🚨  Testing

Tested in localhost

## 🃏 Task Card


- [`BUD22-123`](https://www.notion.so/budops/28fc5005cf3340f68de1468b2fd83b37?v=c01d6b713e204f1f97f8ed3a2a11b464&p=5059183520164f52b3d1c06945eb5e6d&pm=s)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcel

### Dev

- [ ] Guilherme
