### PR TITLE
Fix: repeated tem members on list.

### DIFF
--- a/src/components/Team/CardList/queries.gql
+++ b/src/components/Team/CardList/queries.gql
@@ -21,8 +21,14 @@ query GET_TEAMS {
         users {
           edges {
             node {
+              id
+              firstName
+              nickname
               fullName
+              role
               picture
+              about
+              linkedInProfileAddress
             }
           }
         }
@@ -59,8 +65,14 @@ query GET_USER_TEAMS_AND_COMPANIES {
         users {
           edges {
             node {
+              id
+              firstName
+              nickname
               fullName
+              role
               picture
+              about
+              linkedInProfileAddress
             }
           }
         }
@@ -93,8 +105,14 @@ query GET_USER_TEAMS_AND_COMPANIES {
         users {
           edges {
             node {
+              id
+              firstName
+              nickname
               fullName
+              role
               picture
+              about
+              linkedInProfileAddress
             }
           }
         }


### PR DESCRIPTION
## 🎢 Motivation

Lista de “Membros do Time” está repetindo o último nome da lista sempre que um user faz o seguinte caminho:

1. Acessar a página de um time;
2. Passar o cursor do mouse pelo botão `Times` (no menu superior do Bud)

## 🔧 Solution

Query was missing some parameters

## 🚨  Testing

1. Acessar a página de um time;
2. Passar o cursor do mouse pelo botão `Times` (no menu superior do Bud)

## 🃏 Task Card

## 🔗 Related PRs

## 🍩 Validation

### Canary

- [ ] Marcel
- [ ] Seiji

### Dev

- [ ] Perin
- [x] Guilherme
- [ ] Rodrigo
- [ ] Diego
