### PR TITLE
Feat/exclude retro comments

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -1971,6 +1971,10 @@
     "defaultMessage": "to <highlight>{confidence}</highlight>",
     "description": "This text is displayed as the second line of our confidence tooltip"
   },
+  "IoZbDV": {
+    "defaultMessage": "You want to delete this comment?",
+    "description": "This message appears in delete modal confirmation."
+  },
   "iIm/1E": {
     "defaultMessage": "mentioned you in a comment:",
     "description": "This message is displayed to describe a notification that occurs when a user is tagged in a comment."
@@ -2750,6 +2754,10 @@
   "O4iDCM": {
     "defaultMessage": "Progress",
     "description": "The title of the progress section in our key-result sidebar"
+  },
+  "O60mSP": {
+    "defaultMessage": "Delete",
+    "description": "This message appears as a label on the button used to exclude a comment."
   },
   "OA7DUJ": {
     "defaultMessage": "New Objective",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1283,6 +1283,10 @@
     "defaultMessage": "para <highlight>{confidence}</highlight>",
     "description": "This text is displayed as the second line of our confidence tooltip"
   },
+  "IoZbDV": {
+    "defaultMessage": "Deseja excluir esse comentário?",
+    "description": "This message appears in delete modal confirmation."
+  },
   "IsUZSc": {
     "defaultMessage": "Excluir este Resultado-Chave",
     "description": "This message appears in the button that deletes the key result"
@@ -1622,6 +1626,10 @@
   "O4iDCM": {
     "defaultMessage": "Progresso",
     "description": "The title of the progress section in our key-result sidebar"
+  },
+  "O60mSP": {
+    "defaultMessage": "Excluir",
+    "description": "This message appears as a label on the button used to exclude a comment."
   },
   "OA7DUJ": {
     "defaultMessage": "Novo Objetivo",

--- a/src/components/Routine/RetrospectiveTab/Comments/CommentCard/index.tsx
+++ b/src/components/Routine/RetrospectiveTab/Comments/CommentCard/index.tsx
@@ -2,7 +2,7 @@ import { Flex, Text, VStack, Avatar, Button, HStack } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import React, { useMemo, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
-import { useSetRecoilState } from 'recoil'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
 import regexifyString from 'regexify-string'
 
 import { ConfirmationDialog } from 'src/components/Base/Dialogs/Confirmation/Base/wrapper'
@@ -13,6 +13,7 @@ import { useGetUserDetails } from 'src/components/User/hooks'
 import { User } from 'src/components/User/types'
 import { commentInputInitialValue } from 'src/state/recoil/comments/input'
 import { commentEntityToReply } from 'src/state/recoil/comments/reply-comment'
+import meAtom from 'src/state/recoil/user/me'
 
 import { COMMENT_DOMAIN } from '../../Answers/utils/constants'
 import { AnswerType } from '../../retrospective-tab-content'
@@ -67,6 +68,8 @@ const CommentCard = ({
 
   const origin_entity = `${COMMENT_DOMAIN.routine}:${answerId}`
 
+  const logged_user = useRecoilValue(meAtom)
+
   const { data: user } = useGetUserDetails(userId)
   const setCommentInputValue = useSetRecoilState(commentInputInitialValue)
   const setCommentEntityToReply = useSetRecoilState(commentEntityToReply)
@@ -104,6 +107,8 @@ const CommentCard = ({
     setCommentEntityToReply(entityToReply)
   }
 
+  const isCommentOwner = userId === logged_user
+
   return (
     <HStack spacing={4} my={1} alignItems="flex-start" justifyContent="flex-start" width="full">
       <Avatar width="45px" height="45px" src={user?.picture} />
@@ -136,17 +141,19 @@ const CommentCard = ({
             >
               {intl.formatMessage(messages.replyCommentButton)}
             </Button>
-            <Button
-              p={0}
-              paddingLeft={3}
-              color="brand.500"
-              fontSize={14}
-              fontWeight="normal"
-              height="24px"
-              onClick={() => setIsDialogOpen(true)}
-            >
-              {intl.formatMessage(messages.excludeCommentButton)}
-            </Button>
+            {isCommentOwner && (
+              <Button
+                p={0}
+                paddingLeft={3}
+                color="brand.500"
+                fontSize={14}
+                fontWeight="normal"
+                height="24px"
+                onClick={() => setIsDialogOpen(true)}
+              >
+                {intl.formatMessage(messages.excludeCommentButton)}
+              </Button>
+            )}
             <ConfirmationDialog
               isOpen={isDialogOpen}
               headerImageURL="/images/bud-trash-bin.png"

--- a/src/components/Routine/RetrospectiveTab/Comments/CommentCard/messages.ts
+++ b/src/components/Routine/RetrospectiveTab/Comments/CommentCard/messages.ts
@@ -1,11 +1,24 @@
 import { defineMessages } from 'react-intl'
 
-type RoutineCommentCardMessages = 'replyCommentButton'
+type RoutineCommentCardMessages =
+  | 'replyCommentButton'
+  | 'excludeCommentButton'
+  | 'deleteDialogTitle'
 
 export default defineMessages<RoutineCommentCardMessages>({
   replyCommentButton: {
     defaultMessage: 'Responder',
     id: 'wsXNFt',
     description: 'This message appears as a label on the button used to reply to a comment.',
+  },
+  excludeCommentButton: {
+    defaultMessage: 'Excluir',
+    id: 'O60mSP',
+    description: 'This message appears as a label on the button used to exclude a comment.',
+  },
+  deleteDialogTitle: {
+    defaultMessage: 'Deseja excluir esse comentário?',
+    id: 'IoZbDV',
+    description: 'This message appears in delete modal confirmation.',
   },
 })

--- a/src/components/Routine/RetrospectiveTab/Comments/index.tsx
+++ b/src/components/Routine/RetrospectiveTab/Comments/index.tsx
@@ -4,17 +4,20 @@ import { useIntl } from 'react-intl'
 
 import { User } from 'src/components/User/types'
 
+import { AnswerType } from '../retrospective-tab-content'
+
 import CommentCard from './CommentCard'
 import RoutineCommentsEmptyState from './empty-state'
 import messages from './messages'
 import { Comment } from './types'
 
 type RoutineCommentsProperties = {
+  answerId: AnswerType['id']
   answerOwner?: User['firstName']
   comments: Comment[]
 }
 
-const RoutineComments = ({ answerOwner, comments }: RoutineCommentsProperties) => {
+const RoutineComments = ({ answerId, answerOwner, comments }: RoutineCommentsProperties) => {
   const intl = useIntl()
 
   return (
@@ -24,14 +27,16 @@ const RoutineComments = ({ answerOwner, comments }: RoutineCommentsProperties) =
       </Text>
       <List>
         {comments && comments.length > 0 ? (
-          comments.map(({ id, userId, content, createdAt, entity }) => (
+          comments.map(({ id, userId, content, createdAt, entity, isDeleted }) => (
             <CommentCard
               key={id}
+              answerId={answerId}
               id={id}
               userId={userId}
               comment={content}
               timestamp={createdAt}
               entity={entity}
+              isDeleted={isDeleted}
             />
           ))
         ) : (

--- a/src/components/Routine/RetrospectiveTab/Comments/types.ts
+++ b/src/components/Routine/RetrospectiveTab/Comments/types.ts
@@ -4,4 +4,5 @@ export type Comment = {
   userId: string
   content: string
   createdAt: Date
+  isDeleted: boolean
 }

--- a/src/components/Routine/RetrospectiveTab/retrospective-tab-content-view.tsx
+++ b/src/components/Routine/RetrospectiveTab/retrospective-tab-content-view.tsx
@@ -114,7 +114,11 @@ const RetrospectiveTabContentView = ({
         {answerId && answerDetailed.answers.length > 0 ? (
           <div id="comments-list">
             <AnswerContent answerId={answerId} isLoaded={isLoaded && isUserDetailedLoaded} />
-            <RoutineComments comments={comments} answerOwner={answerDetailed.user.firstName} />
+            <RoutineComments
+              answerId={answerId}
+              comments={comments}
+              answerOwner={answerDetailed.user.firstName}
+            />
             <RoutineCommentsInput
               showLastComment={scrollToShowLastComment}
               routineUser={answerDetailed.user.firstName}

--- a/src/components/Routine/hooks/getCommentsByEntity/get-comments-by-entity.tsx
+++ b/src/components/Routine/hooks/getCommentsByEntity/get-comments-by-entity.tsx
@@ -20,5 +20,9 @@ export const useGetCommentsByEntity = () => {
     setComments(findedComments)
   }
 
-  return { getCommentsByEntity, comments }
+  const refatch = ({ entity }: { entity: Comment['entity'] }) => {
+    getCommentsByEntity({ entity })
+  }
+
+  return { getCommentsByEntity, comments, refatch }
 }


### PR DESCRIPTION
## 🎢 Motivation

Implements a exclude button for retro comments

## 🔧 Solution

- Implements button.
- Implements handle to modify comment state.
- Implements permission to only allow owners to exclude.

## 🚨  Testing

- go to a retro
- make a comment
- exclude the comment
- tries to exclude another one's comment

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-123`](https://www.notion.so/budops/Melhoria-Excluir-coment-rio-Retrospectiva-f0622a3bcd2a47c7a259244576ee8759?pvs=4)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [x] Guilherme
- [ ] Rodrigo
- [ ] Diego
