### PR TITLE
implements feature, users can be marked on check in comments

### DIFF
--- a/src/components/Base/MentionField/index.tsx
+++ b/src/components/Base/MentionField/index.tsx
@@ -1,0 +1,140 @@
+import { useQuery } from '@apollo/client'
+import { Box, useToken } from '@chakra-ui/react'
+import React, { ChangeEvent, useEffect, useState } from 'react'
+import { useIntl } from 'react-intl'
+import { Mention, MentionsInput, SuggestionDataItem } from 'react-mentions'
+
+import { GetUserListQueryResult } from 'src/components/User/AllReachableUsers/wrapper'
+import { User } from 'src/components/User/types'
+import { useConnectionEdges } from 'src/state/hooks/useConnectionEdges/hook'
+import { useRecoilFamilyLoader } from 'src/state/recoil/hooks'
+import { userAtomFamily } from 'src/state/recoil/user'
+
+import queries from './queries/queries.gql'
+import messages from './utils/messages'
+import { renderSuggestion } from './utils/render-suggestion'
+import { MentionFieldProperties } from './utils/types'
+
+export const MentionField = ({ values, setValues, handleSubmit }: MentionFieldProperties) => {
+  const intl = useIntl()
+
+  const { data } = useQuery<GetUserListQueryResult>(queries.GET_USER_LIST)
+  const [usersMention, setUsersMention] = useState<SuggestionDataItem[]>([])
+  const [users, setUserEdges] = useConnectionEdges<User>()
+  const [loadUsers] = useRecoilFamilyLoader(userAtomFamily)
+
+  const [brand500, gray200, gray400, newGray200, newGray300, newGray900]: string[] = useToken(
+    'colors',
+    ['brand.500', 'gray.200', 'gray.400', 'new-gray.200', 'new-gray.300', 'new-gray.900'],
+  )
+  const [shadow] = useToken('shadows', ['for-background.medium'])
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setValues((previousValues) => ({
+      ...previousValues,
+      comment: event.target.value,
+    }))
+  }
+
+  const handleCommentsInputKeyDown = (event: any) => {
+    const keyCode = event.which || event.key
+
+    if (keyCode === 13 && !event.shiftKey) {
+      event.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  useEffect(() => {
+    if (data) setUserEdges(data.users.edges)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  useEffect(() => {
+    if (!users) return
+
+    const usersMentionTemporary = users.map(({ id, fullName }) => ({ id, display: fullName }))
+
+    loadUsers(users)
+    setUsersMention(usersMentionTemporary)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [users])
+
+  return (
+    <Box
+      borderWidth={1}
+      flexGrow={1}
+      maxW="full"
+      wordBreak="break-word"
+      transition="0.2s box-shadow ease-in"
+      overflow="visible"
+      position="relative"
+      fontSize="md"
+      minHeight="100px"
+      color={gray400}
+      borderColor={gray200}
+      borderRadius={2}
+      px={4}
+      py={2}
+      pr={10}
+    >
+      <MentionsInput
+        allowSuggestionsAboveCursor
+        value={values.comment}
+        placeholder={intl.formatMessage(messages.placeholder)}
+        style={{
+          input: {
+            resize: 'none',
+            width: '100%',
+            outline: 'none',
+            color: newGray900,
+          },
+          suggestions: {
+            top: 'auto',
+            left: 'auto',
+            bottom: '15px',
+            right: '0px',
+            backgroundColor: 'transparent',
+            list: {
+              border: `1px solid ${newGray300}`,
+              marginBottom: '34px',
+              backgroundColor: '#fff',
+              padding: '14px',
+              width: '421px',
+              borderRadius: '8px',
+              boxShadow: shadow,
+              maxHeight: '50vh',
+              overflowY: 'auto',
+            },
+            item: {
+              padding: '6px',
+              '&focused': {
+                background: newGray200,
+                borderRadius: '8px',
+              },
+            },
+          },
+        }}
+        onKeyDown={handleCommentsInputKeyDown}
+        onChange={handleChange as any}
+      >
+        <Mention
+          appendSpaceOnAdd
+          trigger="@"
+          style={{
+            position: 'relative',
+            zIndex: 1,
+            color: brand500,
+            left: -1,
+            top: -1,
+            textShadow:
+              '1px 1px 1px white, 1px -1px 1px white, -1px 1px 1px white, -1px -1px 1px white',
+            pointerEvents: 'none',
+          }}
+          data={usersMention}
+          renderSuggestion={renderSuggestion}
+        />
+      </MentionsInput>
+    </Box>
+  )
+}

--- a/src/components/Base/MentionField/queries/queries.gql
+++ b/src/components/Base/MentionField/queries/queries.gql
@@ -1,0 +1,28 @@
+query GET_USER_LIST {
+  users(first: 1000) {
+    edges {
+      node {
+        id
+        firstName
+        nickname
+        status
+        linkedInProfileAddress
+        about
+        fullName
+        role
+        picture
+        teams {
+          edges {
+            node {
+              id
+              name
+              owner {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/Base/MentionField/utils/messages.ts
+++ b/src/components/Base/MentionField/utils/messages.ts
@@ -1,0 +1,35 @@
+import { defineMessages } from 'react-intl'
+
+type KeyResultsSectionAddCommentMessage =
+  | 'paperPlaneIconTitle'
+  | 'paperPlaneIconDesc'
+  | 'placeholder'
+  | 'emptyCommentWarningMessage'
+
+export default defineMessages<KeyResultsSectionAddCommentMessage>({
+  paperPlaneIconTitle: {
+    defaultMessage: 'Enviar comentário',
+    id: 'CMMxiV',
+    description:
+      'The title displayed in the tooltip when the user hovers our paper plane icon in our add comment form',
+  },
+
+  paperPlaneIconDesc: {
+    defaultMessage: 'Um ícone de um avião de papel. Ao clicar nele você irá enviar um comentário',
+    id: '/aK0UI',
+    description: 'The alternative text explaining our paper plane icon',
+  },
+
+  placeholder: {
+    defaultMessage: 'Comente aqui! Para marcar alguém, use @ :)',
+    id: 'MgJJAJ',
+    description:
+      'This text is displayed in our comment input in our key result drawers when it has no value',
+  },
+
+  emptyCommentWarningMessage: {
+    defaultMessage: 'Digite algo para comentar! :)',
+    id: 'JB7c65',
+    description: 'This text is displayed if the user try comment with empty input.',
+  },
+})

--- a/src/components/Base/MentionField/utils/render-suggestion.tsx
+++ b/src/components/Base/MentionField/utils/render-suggestion.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { SuggestionDataItem } from 'react-mentions'
+
+import { NamedAvatar } from 'src/components/User'
+
+export const renderSuggestion = (suggestion: SuggestionDataItem) => (
+  <div>
+    <NamedAvatar
+      canHover
+      nameColor="black.900"
+      subtitleType="role"
+      userID={suggestion.id.toString()}
+    />
+  </div>
+)

--- a/src/components/Base/MentionField/utils/types.ts
+++ b/src/components/Base/MentionField/utils/types.ts
@@ -1,0 +1,15 @@
+import { CheckInFormValues } from 'src/components/KeyResult/CheckInForm/form'
+import { KeyResultComment } from 'src/components/KeyResult/types'
+
+export interface KeyResultSectionAddCommentInitialValues {
+  text: KeyResultComment['text']
+}
+
+export interface MentionFieldProperties {
+  values: CheckInFormValues
+  setValues: (
+    values: React.SetStateAction<CheckInFormValues>,
+    shouldValidate?: boolean | undefined,
+  ) => void
+  handleSubmit: (event?: React.FormEvent<HTMLFormElement> | undefined) => void
+}

--- a/src/components/KeyResult/CheckInForm/Fields/Comment/input.tsx
+++ b/src/components/KeyResult/CheckInForm/Fields/Comment/input.tsx
@@ -1,34 +1,22 @@
-import { Box, Flex, FormLabel, Textarea } from '@chakra-ui/react'
+import { Box, Flex, FormLabel } from '@chakra-ui/react'
 import { useFormikContext } from 'formik'
-import React, { ChangeEvent, useEffect, useState } from 'react'
+import React, { FocusEvent } from 'react'
 import { useIntl } from 'react-intl'
 
+import { MentionField } from 'src/components/Base/MentionField'
 import { CheckInFormValues } from 'src/components/KeyResult/CheckInForm/form'
 
 import messages from './messages'
 
 const CheckInFormFieldCommentInput = () => {
   const intl = useIntl()
-  const [value, setValue] = useState<string | undefined>()
-  const { values, setFieldValue } = useFormikContext<CheckInFormValues>()
-
-  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(event.target.value)
-  }
-
-  const handleBlur = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setFieldValue('comment', event.target.value)
-  }
-
-  useEffect(() => {
-    setValue(values?.comment)
-  }, [values, setValue])
+  const { values, setValues, handleSubmit } = useFormikContext<CheckInFormValues>()
 
   return (
     <Box>
       <FormLabel>{intl.formatMessage(messages.inputLabel)}</FormLabel>
       <Flex direction="column" gridGap={4}>
-        <Textarea value={value} onChange={handleChange} onBlur={handleBlur} />
+        <MentionField values={values} setValues={setValues} handleSubmit={handleSubmit} />
       </Flex>
     </Box>
   )

--- a/src/components/KeyResult/CheckInForm/Fields/Comment/input.tsx
+++ b/src/components/KeyResult/CheckInForm/Fields/Comment/input.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, FormLabel } from '@chakra-ui/react'
 import { useFormikContext } from 'formik'
-import React, { FocusEvent } from 'react'
+import React from 'react'
 import { useIntl } from 'react-intl'
 
 import { MentionField } from 'src/components/Base/MentionField'

--- a/src/components/KeyResult/CheckInForm/form.tsx
+++ b/src/components/KeyResult/CheckInForm/form.tsx
@@ -70,6 +70,9 @@ const CheckInForm = ({
 }: CheckInFormProperties) => {
   const intl = useIntl()
   const { dispatch: dispatchEvent } = useEvent(EventType.CREATED_KEY_RESULT_CHECK_IN)
+  const { dispatch: dispatchCreatedKeyResultCommentEvent } = useEvent(
+    EventType.CREATED_KEY_RESULT_COMMENT,
+  )
   const isCreated = useRecoilValue(createdByCheckInNotificationAtom)
   const userId = useRecoilValue(meAtom)
 
@@ -89,6 +92,7 @@ const CheckInForm = ({
       onCompleted: (data) => {
         setLatestKeyResultCheckIn(data.createKeyResultCheckIn)
         if (onCompleted) onCompleted(data.createKeyResultCheckIn)
+        dispatchCreatedKeyResultCommentEvent({})
         dispatchEvent({
           createdByNotification: Boolean(isCreated),
           userId,

--- a/src/components/KeyResult/CheckInForm/form.tsx
+++ b/src/components/KeyResult/CheckInForm/form.tsx
@@ -92,7 +92,6 @@ const CheckInForm = ({
       onCompleted: (data) => {
         setLatestKeyResultCheckIn(data.createKeyResultCheckIn)
         if (onCompleted) onCompleted(data.createKeyResultCheckIn)
-        dispatchCreatedKeyResultCommentEvent({})
         dispatchEvent({
           createdByNotification: Boolean(isCreated),
           userId,

--- a/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/comment.tsx
+++ b/src/components/KeyResult/Single/Sections/Timeline/Cards/CheckIn/comment.tsx
@@ -1,9 +1,9 @@
 import { Flex, Heading, SkeletonText } from '@chakra-ui/react'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
-import { ExpandableText } from 'src/components/Base'
 import { KeyResultCheckIn } from 'src/components/KeyResult/types'
+import { insertMentionInString } from 'src/components/Routine/RetrospectiveTab/Comments/CommentCard'
 
 import messages from './messages'
 
@@ -17,6 +17,16 @@ const KeyResultSectionTimelineCardCheckInComment = ({
   const intl = useIntl()
   const isLoaded = Boolean(comment)
 
+  const formattedCommentText = useMemo(() => {
+    if (comment) {
+      return comment.split('\n').map((line) => (
+        <span key={line} style={{ display: 'block' }}>
+          {insertMentionInString(line)}
+        </span>
+      ))
+    }
+  }, [comment])
+
   return (
     <Flex direction="column" gridGap={2}>
       <Heading
@@ -29,12 +39,7 @@ const KeyResultSectionTimelineCardCheckInComment = ({
         {intl.formatMessage(messages.commentTitle)}
       </Heading>
       <SkeletonText isLoaded={isLoaded} noOfLines={4}>
-        <ExpandableText
-          text={comment ?? ''}
-          fontSize="md"
-          color="new-gray.900"
-          maxCollapsedLength={150}
-        />
+        {formattedCommentText ?? ''}
       </SkeletonText>
     </Flex>
   )


### PR DESCRIPTION
## 🎢 Motivation

A brief summary of the purpose of this PR.

## 🔧 Solution

Implements the feature that allows the user to mark another in check-in comments.

## 🚨  Testing

1 - Go to app
2 - Go to KR
3 - Make a check-in
4 - Comment the check-in
5 - Mark user
6 - Check email to see if you where marked

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-123`](https://www.notion.so/budops/Melhoria-Como-KR-Owner-gostaria-de-fazer-um-check-in-e-marcar-pessoas-que-preciso-na-mesma-a-o-b5c4a5601d8d4dd59e2887c7a8063ead?pvs=4)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
