### PR TITLE
Feat/reset csat flag

### DIFF
--- a/src/components/Base/NoticesBanner/index.tsx
+++ b/src/components/Base/NoticesBanner/index.tsx
@@ -6,11 +6,10 @@ import useLocalStorage from 'src/state/hooks/useLocalStorage/hook'
 
 import messages from './messages'
 
-export const oldStorageKey = 'bud-platform-speed-survey'
-export const storageKey = 'bud-platform-speed-survey-2'
+export const storageKey = 'bud-platform-speed-survey'
 
 const NoticesBanner = () => {
-  const { get, register, clear } = useLocalStorage()
+  const { get, register } = useLocalStorage()
 
   const intl = useIntl()
 
@@ -19,24 +18,20 @@ const NoticesBanner = () => {
   useEffect(() => {
     const time = setTimeout(() => {
       setIsOpen(() => {
-        const oldValueStoraged = get(oldStorageKey)
         const valueStoraged = get(storageKey)
-
-        if (oldValueStoraged !== undefined) {
-          clear(oldStorageKey)
+        if (valueStoraged === false || valueStoraged === undefined) {
+          return true
         }
 
-        if (!valueStoraged) return valueStoraged
-
-        return true
+        return false
       })
     }, 2300)
 
     return () => clearTimeout(time)
-  }, [get, clear])
+  }, [get])
 
   const handleCloseBanner = useCallback(() => {
-    register(storageKey, false)
+    register(storageKey, true)
     setIsOpen(false)
   }, [register])
 

--- a/src/components/Base/NoticesBanner/index.tsx
+++ b/src/components/Base/NoticesBanner/index.tsx
@@ -19,11 +19,11 @@ const NoticesBanner = () => {
     const time = setTimeout(() => {
       setIsOpen(() => {
         const valueStoraged = get(storageKey)
-        if (valueStoraged === false || valueStoraged === undefined) {
-          return true
+        if (valueStoraged === '10-12-24') {
+          return false
         }
 
-        return false
+        return true
       })
     }, 2300)
 
@@ -31,7 +31,7 @@ const NoticesBanner = () => {
   }, [get])
 
   const handleCloseBanner = useCallback(() => {
-    register(storageKey, true)
+    register(storageKey, '10-12-24')
     setIsOpen(false)
   }, [register])
 

--- a/src/components/Base/NoticesBanner/index.tsx
+++ b/src/components/Base/NoticesBanner/index.tsx
@@ -6,10 +6,11 @@ import useLocalStorage from 'src/state/hooks/useLocalStorage/hook'
 
 import messages from './messages'
 
-export const storageKey = 'bud-platform-speed-survey'
+export const oldStorageKey = 'bud-platform-speed-survey'
+export const storageKey = 'bud-platform-speed-survey-2'
 
 const NoticesBanner = () => {
-  const { get, register } = useLocalStorage()
+  const { get, register, clear } = useLocalStorage()
 
   const intl = useIntl()
 
@@ -18,17 +19,21 @@ const NoticesBanner = () => {
   useEffect(() => {
     const time = setTimeout(() => {
       setIsOpen(() => {
+        const oldValueStoraged = get(oldStorageKey)
         const valueStoraged = get(storageKey)
-        if (valueStoraged === false) {
-          return valueStoraged
+
+        if (oldValueStoraged !== undefined) {
+          clear(oldStorageKey)
         }
+
+        if (!valueStoraged) return valueStoraged
 
         return true
       })
     }, 2300)
 
     return () => clearTimeout(time)
-  }, [get])
+  }, [get, clear])
 
   const handleCloseBanner = useCallback(() => {
     register(storageKey, false)


### PR DESCRIPTION
## 🎢 Motivation

Allow more responses on speed survey.

## 🔧 Solution

Inverts logic that recognizes how already responded. 

## 🚨  Testing

Check if speed survey starts to appears on top of bud.

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-123`](https://www.notion.so/budops/Habilitar-pesquisa-de-CSAT-Performance-Bud-b40994adc11b4e95bfa9f8ed1eb02fd1?pvs=4)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
