### PR TITLE
fix task not being showed in task manager board

### DIFF
--- a/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-task-in-kr.tsx
+++ b/src/components/KeyResult/Single/Sections/Checklist/ActionButtons/create-task-in-kr.tsx
@@ -81,7 +81,7 @@ export const CreateTaskButton = ({
         tags: [],
         orderindex: 0,
         keyResult: keyResultID,
-        cycle: '',
+        cycle: undefined,
       })
     }
 


### PR DESCRIPTION
## 🎢 [Summary](https://www.notion.so/budops/XXXXXXXXX)

- Sending cycle as null makes backend search for a compatible cycle for the task. 